### PR TITLE
CI: Fix dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'solana-program/memo'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'solana-program'
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
#### Problem

The dependabot job has a typo, and only runs on solana-program/memo. This means that it currently won't ever run.

#### Summary of changes

This is a bit error-prone, so use the `repository_owner` instead.