### PR TITLE
CI: Update git-cliff action to v4

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -163,13 +163,10 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: |
-            "${{ steps.publish.outputs.old_git_tag }}"..main
-            --include-path "${{ inputs.package_path }}/**"
-            --github-repo "${{ github.repository }}"
+          args: "${{ steps.publish.outputs.old_git_tag }}"..main --include-path "${{ inputs.package_path }}/**" --github-repo "${{ github.repository }}"
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

The v3 git-cliff action is very out of date, but still being used by this repo.

#### Summary of changes

Bump the git-cliff action version to v4.