### PR TITLE
CI: Fix git-cliff args

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -166,7 +166,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: "${{ steps.publish.outputs.old_git_tag }}"..main --include-path "${{ inputs.package_path }}/**" --github-repo "${{ github.repository }}"
+          args: ${{ steps.publish.outputs.old_git_tag }}..HEAD --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

The current yaml isn't actually recognized for the publish job.

#### Summary of changes

Remove some quotes. While I was at it, I also fixed the tag to `HEAD` instead of `main`, which is useful in case we ever add backport branches.