### PR TITLE
program: Deprecate instruction re-exports

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,3 +1,6 @@
 //! Program instructions
-
+#![deprecated(
+    since = "7.1.0",
+    note = "Use `spl_associated_token_account_interface::instruction` instead and remove `spl_associated_token_account` as a dependency"
+)]
 pub use spl_associated_token_account_interface::instruction::*;

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -18,7 +18,7 @@ use solana_program::{
 };
 #[deprecated(
     since = "4.1.0",
-    note = "Use `spl-associated-token-account-interface` crate instead."
+    note = "Use `spl_associated_token_account_interface::address` instead and remove `spl_associated_token_account` as a dependency"
 )]
 pub use spl_associated_token_account_interface::address::{
     get_associated_token_address, get_associated_token_address_with_program_id,


### PR DESCRIPTION
#### Problem

We need people to know about spl-associated-token-account-interface so they can start using it, but we haven't really promoted it.

#### Summary of changes

Do the right thing, and make the deprecations louder. Since rust doesn't warn for deprecated re-exports, there's not much we can do for the address derivation functions.