### PR TITLE
harness: Allow publishing

### DIFF
--- a/mollusk_harness/Cargo.toml
+++ b/mollusk_harness/Cargo.toml
@@ -3,7 +3,6 @@ name = "spl-associated-token-account-mollusk-harness"
 version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
-publish = false
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

I tried to publish the crate, and forgot that it still has `publish = false` set on it.

#### Summary of changes

Allow publishing.