### PR TITLE
harness: Add more required fields for publishing

### DIFF
--- a/mollusk_harness/Cargo.toml
+++ b/mollusk_harness/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "spl-associated-token-account-mollusk-harness"
 version = "1.0.0"
-edition = "2021"
+description = "SPL Associated Token Account Mollusk Testing Harness"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/associated-token-account"
 license = "Apache-2.0"
+edition = "2021"
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem

For some reason, publish's dry-run mode doesn't check for fields required to upload. The mollusk test harness crate is missing fields.

#### Summary of changes

Add. Those. Fields.