### PR TITLE
p-ata: remove bump hints

### DIFF
--- a/mollusk_harness/src/lib.rs
+++ b/mollusk_harness/src/lib.rs
@@ -58,22 +58,20 @@ fn add_token_program_by_name(
 }
 
 /// The type of ATA creation instruction to build.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum CreateAtaInstructionType {
-    /// The standard `Create` instruction, which can optionally include a bump seed and account length.
-    Create {
-        bump: Option<u8>,
-        account_len: Option<u16>,
-    },
-    /// The `CreateIdempotent` instruction, which can optionally include a bump seed.
-    CreateIdempotent { bump: Option<u8> },
+    /// The standard `Create` instruction.
+    #[default]
+    Create,
+    /// The `CreateIdempotent` instruction.
+    CreateIdempotent,
 }
 
-impl Default for CreateAtaInstructionType {
-    fn default() -> Self {
-        Self::Create {
-            bump: None,
-            account_len: None,
+impl From<CreateAtaInstructionType> for u8 {
+    fn from(value: CreateAtaInstructionType) -> Self {
+        match value {
+            CreateAtaInstructionType::Create => 0,
+            CreateAtaInstructionType::CreateIdempotent => 1,
         }
     }
 }
@@ -571,7 +569,7 @@ impl AtaTestHarness {
             wallet,
             mint,
             self.token_program_id,
-            CreateAtaInstructionType::CreateIdempotent { bump: None },
+            CreateAtaInstructionType::CreateIdempotent,
         );
 
         // Replace the ATA address with the wrong account address
@@ -637,29 +635,6 @@ impl AtaTestHarness {
     }
 }
 
-/// Encodes the instruction data payload for ATA creation-related instructions.
-pub fn encode_create_ata_instruction_data(instruction_type: &CreateAtaInstructionType) -> Vec<u8> {
-    match instruction_type {
-        CreateAtaInstructionType::Create { bump, account_len } => {
-            let mut data = vec![0]; // Discriminator for Create
-            if let Some(b) = bump {
-                data.push(*b);
-                if let Some(len) = account_len {
-                    data.extend_from_slice(&len.to_le_bytes());
-                }
-            }
-            data
-        }
-        CreateAtaInstructionType::CreateIdempotent { bump } => {
-            let mut data = vec![1]; // Discriminator for CreateIdempotent
-            if let Some(b) = bump {
-                data.push(*b);
-            }
-            data
-        }
-    }
-}
-
 /// Build a create associated token account instruction with a given discriminator
 pub fn build_create_ata_instruction(
     ata_program_id: Pubkey,
@@ -681,7 +656,7 @@ pub fn build_create_ata_instruction(
             AccountMeta::new_readonly(token_program, false),
             AccountMeta::new_readonly(rent::id(), false),
         ],
-        data: encode_create_ata_instruction_data(&instruction_type),
+        data: vec![u8::from(instruction_type)],
     }
 }
 

--- a/program/tests/create_always.rs
+++ b/program/tests/create_always.rs
@@ -24,10 +24,7 @@ fn create_rejects_existing_ata(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::Create {
-            bump: None,
-            account_len: None,
-        },
+        CreateAtaInstructionType::Create,
     );
 
     harness

--- a/program/tests/create_idempotent.rs
+++ b/program/tests/create_idempotent.rs
@@ -38,7 +38,7 @@ fn idempotent_rejects_non_token_owned_canonical_ata(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness
@@ -72,7 +72,7 @@ fn idempotent_rejects_uninitialized_token_owned_canonical_ata(token_program_id: 
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness
@@ -106,7 +106,7 @@ fn idempotent_rejects_invalid_data_token_owned_canonical_ata(token_program_id: P
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness
@@ -136,7 +136,7 @@ fn idempotent_rejects_packed_uninitialized_token_owned_canonical_ata(token_progr
         wallet,
         harness.mint.unwrap(),
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     // Zeroing the account state byte defeats the idempotent fast-path (unpack
@@ -162,7 +162,7 @@ fn idempotent_rejects_wrong_owner(token_program_id: Pubkey) {
         harness.wallet.unwrap(),
         harness.mint.unwrap(),
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness
@@ -192,7 +192,7 @@ fn idempotent_rejects_wrong_mint(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness.ctx.process_and_validate_instruction(
@@ -216,7 +216,7 @@ fn idempotent_accepts_preexisting_valid_ata(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness.ctx.process_and_validate_instruction(
@@ -256,7 +256,7 @@ fn idempotent_accepts_frozen_ata(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::CreateIdempotent { bump: None },
+        CreateAtaInstructionType::CreateIdempotent,
     );
 
     harness.ctx.process_and_validate_instruction(

--- a/program/tests/create_return_data.rs
+++ b/program/tests/create_return_data.rs
@@ -29,10 +29,7 @@ fn create_rejects_nested_return_data_from_mock_token_program_when_child_is_not_f
         1_000_000,
         vec![mock_behavior],
     );
-    let mut instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create {
-        bump: None,
-        account_len: None,
-    });
+    let mut instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create);
     instruction
         .accounts
         .push(AccountMeta::new_readonly(child_program_id, false));
@@ -61,10 +58,7 @@ fn create_rejects_missing_account_size_return_data_from_mock_token_program() {
         1_000_000,
         vec![mock_behavior],
     );
-    let instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create {
-        bump: None,
-        account_len: None,
-    });
+    let instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create);
 
     harness.ctx.process_and_validate_instruction(
         &instruction,
@@ -90,10 +84,7 @@ fn create_rejects_malformed_account_size_return_data_from_mock_token_program() {
         1_000_000,
         vec![mock_behavior],
     );
-    let instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create {
-        bump: None,
-        account_len: None,
-    });
+    let instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create);
 
     harness.ctx.process_and_validate_instruction(
         &instruction,

--- a/program/tests/create_shared.rs
+++ b/program/tests/create_shared.rs
@@ -31,10 +31,7 @@ fn create_rejects_too_few_accounts(token_program_id: Pubkey) {
         wallet,
         mint,
         token_program_id,
-        CreateAtaInstructionType::Create {
-            bump: None,
-            account_len: None,
-        },
+        CreateAtaInstructionType::Create,
     );
     instruction.accounts.truncate(5);
 
@@ -62,10 +59,7 @@ fn create_rejects_mismatch_derivation(token_program_id: Pubkey) {
             wallet,
             mint,
             token_program_id,
-            CreateAtaInstructionType::Create {
-                bump: None,
-                account_len: None,
-            },
+            CreateAtaInstructionType::Create,
         );
 
         instruction.accounts[account_idx] = if account_idx == 1 {
@@ -83,12 +77,9 @@ fn create_rejects_mismatch_derivation(token_program_id: Pubkey) {
 
 fn instruction_type(idempotent: bool) -> CreateAtaInstructionType {
     if idempotent {
-        CreateAtaInstructionType::CreateIdempotent { bump: None }
+        CreateAtaInstructionType::CreateIdempotent
     } else {
-        CreateAtaInstructionType::Create {
-            bump: None,
-            account_len: None,
-        }
+        CreateAtaInstructionType::Create
     }
 }
 


### PR DESCRIPTION
This PR removes the bump hints from the test harness. The intent is to remove plumbing for a feature that (if approved) we will not use.

### Background

https://github.com/solana-program/associated-token-account/pull/102 explored a number of ATA optimizations, one of which included bump hints.

The idea was if the client already knows the bump, the program could avoid recomputing it. But, it only helps if the program is willing to trust the supplied bump. In practice, the program still needs to validate the input and verify there is not better valid bump above the hinted one. Doing the computation for that verification removes the expected CU savings.

### Local Bench Work

Re-implemented the bump hint work from the reference PR and got these results:

| Scenario                            | main | branch (no hint) | branch (with hint) | no hint vs main | with hint vs main |
|-------------------------------------|-----:|-----------------:|-------------------:|----------------:|------------------:|
| create (spl-token)                  | 3222 |             3258 |               3248 |             +36 |               +26 |
| create (token-2022)                 | 5266 |             5301 |               5291 |             +35 |               +25 |
| create_idempotent (new, spl-token)  | 4317 |             4351 |               4357 |             +34 |               +40 |
| create_idempotent (new, token-2022) | 5637 |             5671 |               5667 |             +34 |               +30 |
| create (prefunded, spl-token)       | 3222 |             3258 |               3248 |             +36 |               +26 |
| create (prefunded, token-2022)      | 5266 |             5301 |               5291 |             +35 |               +25 |

Across the board, the CUs increased. Also, It was a feature that had a decent amount of complexity. In short, the results don't justify it. 