### PR TITLE
p-ata: Implement bump hints

### DIFF
--- a/pinocchio/interface/src/pda.rs
+++ b/pinocchio/interface/src/pda.rs
@@ -1,6 +1,6 @@
 //! Address derivation helpers for Associated Token Account program-derived addresses.
 
-use {pinocchio::error::ProgramError, solana_address::Address};
+use pinocchio::{Address, error::ProgramError};
 
 #[cfg_attr(feature = "codama", derive(codama::CodamaPda))]
 #[cfg_attr(
@@ -75,8 +75,9 @@ impl AssociatedTokenPda {
             token_mint_address.as_ref(),
         ];
 
-        if let Some(first_higher_bump) = bump.checked_add(1) {
-            for higher_bump in first_higher_bump..=u8::MAX {
+        if bump < u8::MAX {
+            #[allow(clippy::arithmetic_side_effects)]
+            for higher_bump in (bump + 1)..=u8::MAX {
                 let higher_bump_addr =
                     Address::derive_address(&seeds, Some(higher_bump), program_id);
                 if !higher_bump_addr.is_on_curve() {

--- a/pinocchio/interface/src/pda.rs
+++ b/pinocchio/interface/src/pda.rs
@@ -1,6 +1,6 @@
 //! Address derivation helpers for Associated Token Account program-derived addresses.
 
-use solana_address::Address;
+use {pinocchio::error::ProgramError, solana_address::Address};
 
 #[cfg_attr(feature = "codama", derive(codama::CodamaPda))]
 #[cfg_attr(
@@ -53,5 +53,38 @@ impl AssociatedTokenPda {
             token_mint_address,
         )
         .0
+    }
+
+    /// Derives the associated token account address for a caller-supplied bump.
+    ///
+    /// This rejects non-canonical bumps by verifying that no higher bump produces an
+    /// off-curve PDA. Note: it does not verify that the supplied bump itself is off-curve.
+    /// Callers must either rely on a subsequent signed PDA invocation to reject an
+    /// on-curve address or manually check `is_on_curve()` before accepting the derived
+    /// address.
+    pub fn derive_address_with_bump_hint(
+        program_id: &Address,
+        wallet_address: &Address,
+        token_program_id: &Address,
+        token_mint_address: &Address,
+        bump: u8,
+    ) -> Result<Address, ProgramError> {
+        let seeds = [
+            wallet_address.as_ref(),
+            token_program_id.as_ref(),
+            token_mint_address.as_ref(),
+        ];
+
+        if let Some(first_higher_bump) = bump.checked_add(1) {
+            for higher_bump in first_higher_bump..=u8::MAX {
+                let higher_bump_addr =
+                    Address::derive_address(&seeds, Some(higher_bump), program_id);
+                if !higher_bump_addr.is_on_curve() {
+                    return Err(ProgramError::InvalidSeeds);
+                }
+            }
+        }
+
+        Ok(Address::derive_address(&seeds, Some(bump), program_id))
     }
 }

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,30 @@
+#### 2026-05-19 02:45:39.155444 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3208 | +1 |
+| create_with_args (spl-token) | 3013 | -134 |
+| create (token-2022) | 5246 | +1 |
+| create_with_args (token-2022) | 5051 | -133 |
+| create_idempotent (new, spl-token) | 4300 | +2 |
+| create_with_args_idempotent (new, spl-token) | 4106 | -131 |
+| create_idempotent (new, token-2022) | 5613 | +1 |
+| create_with_args_idempotent (new, token-2022) | 5420 | -130 |
+| create_idempotent (existing, spl-token) | 548 | -- |
+| create_with_args_idempotent (existing, spl-token) | 605 | +38 |
+| create_idempotent (existing, token-2022) | 1634 | -- |
+| create_with_args_idempotent (existing, token-2022) | 1694 | +41 |
+| create (prefunded, spl-token) | 3208 | +1 |
+| create_with_args (prefunded, spl-token) | 3013 | -134 |
+| create (prefunded, token-2022) | 5246 | +1 |
+| create_with_args (prefunded, token-2022) | 5051 | -133 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5191 | -1 |
+| recover_nested (owner=token-2022, nested=token-2022) | 7055 | -1 |
+| recover_nested (owner=spl-token, nested=token-2022) | 9611 | -1 |
+| recover_nested (owner=token-2022, nested=spl-token) | 5561 | -1 |
+
 #### 2026-05-16 09:50:42.971998 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -17,8 +17,7 @@ pub(crate) fn process_create_associated_token_account(
     accounts: &mut [AccountView],
     create_mode: CreateMode,
     accept_rent_sysvar: bool,
-    // TODO: Use in later PRs
-    _bump_hint: Option<u8>,
+    bump_hint: Option<u8>,
     _account_len_hint: Option<u32>,
 ) -> ProgramResult {
     let [
@@ -42,13 +41,25 @@ pub(crate) fn process_create_associated_token_account(
         None
     };
 
-    let (associated_token_address, bump_seed) = AssociatedTokenPda::derive_address_and_bump_seed(
-        program_id,
-        wallet.address(),
-        token_program.address(),
-        mint.address(),
-    );
-    if associated_token_address != *associated_token_account.address() {
+    let (derived_ata_addr, bump_seed) = match bump_hint {
+        Some(bump) => (
+            AssociatedTokenPda::derive_address_with_bump_hint(
+                program_id,
+                wallet.address(),
+                token_program.address(),
+                mint.address(),
+                bump,
+            )?,
+            bump,
+        ),
+        None => AssociatedTokenPda::derive_address_and_bump_seed(
+            program_id,
+            wallet.address(),
+            token_program.address(),
+            mint.address(),
+        ),
+    };
+    if derived_ata_addr != *associated_token_account.address() {
         return Err(ProgramError::InvalidSeeds);
     }
 
@@ -70,6 +81,13 @@ pub(crate) fn process_create_associated_token_account(
                     }
                     if token_account.mint() != mint.address() {
                         return Err(ProgramError::InvalidAccountData);
+                    }
+                    // `derive_address_with_bump_hint()` rejects higher off-curve bumps but
+                    // doesn't check whether the hinted bump itself is off-curve. Create paths
+                    // validate that through `invoke_signed()`, but this no-op path returns early,
+                    // so check it here.
+                    if bump_hint.is_some() && derived_ata_addr.is_on_curve() {
+                        return Err(ProgramError::InvalidSeeds);
                     }
                     // Confirmed `CreateIdempotent` no-op
                     return Ok(());

--- a/pinocchio/program/tests/bump.rs
+++ b/pinocchio/program/tests/bump.rs
@@ -1,0 +1,320 @@
+mod common;
+
+use {
+    common::expected_bump,
+    mollusk_svm_programs_token::token,
+    mollusk_svm_result::Check,
+    pinocchio_associated_token_account_interface::instruction::CreateMode,
+    solana_address::Address,
+    solana_instruction::{AccountMeta, error::InstructionError},
+    solana_program_error::ProgramError,
+    solana_program_option::COption,
+    solana_program_pack::Pack,
+    spl_associated_token_account_interface::address::get_associated_token_address_and_bump_seed,
+    spl_associated_token_account_mollusk_harness::{
+        AccountBuilder, AtaProgram, AtaTestHarness, CreateAtaInstructionType,
+        token_account_rent_exempt_balance,
+    },
+    test_case::{test_case, test_matrix},
+};
+
+const MINT: Address = Address::from_str_const("8N6gdBxJaZUG9cBnSSaHDsx7vMeQ4VR1LmCmk9SCu38s");
+
+fn ata_address_with_bump(
+    wallet: &Address,
+    mint: &Address,
+    token_program_id: &Address,
+    bump: u8,
+) -> Address {
+    Address::derive_address(
+        &[wallet.as_ref(), token_program_id.as_ref(), mint.as_ref()],
+        Some(bump),
+        &spl_associated_token_account_interface::program::id(),
+    )
+}
+
+fn create_mint_account(token_program_id: &Address) -> AtaTestHarness {
+    let mut harness = AtaTestHarness::new_with_ata_program(token_program_id, AtaProgram::Pinocchio);
+    harness.ctx.account_store.borrow_mut().insert(
+        MINT,
+        token::create_account_for_mint(spl_token_interface::state::Mint {
+            mint_authority: COption::None,
+            supply: 0,
+            decimals: 6,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        }),
+    );
+    harness.mint = Some(MINT);
+    harness
+}
+
+#[test_case(
+    255,
+    254,
+    Address::from_str_const("1117mWrzzrZr312ebPDHu8tbfMwFNvCvMbr6WepCNG")
+)]
+#[test_case(
+    254,
+    253,
+    Address::from_str_const("111FJo4zLAGU9nzTWa6EnbV4VAmtG4FR8kcokrtZYr")
+)]
+#[test_case(
+    253,
+    250,
+    Address::from_str_const("3zPynWFGj3nyJBtHhCy8UEJoGvbn1TmgHca2afHTSByQ")
+)]
+fn create_with_args_rejects_lower_off_curve_bump_hint(
+    canonical_bump: u8,
+    lower_bump: u8,
+    wallet: Address,
+) {
+    let token_program_id = spl_token_interface::id();
+
+    let (canonical_addr, actual_canonical_bump) = get_associated_token_address_and_bump_seed(
+        &wallet,
+        &MINT,
+        &spl_associated_token_account_interface::program::id(),
+        &token_program_id,
+    );
+    assert_eq!(actual_canonical_bump, canonical_bump);
+    let lower_bump_addr = ata_address_with_bump(&wallet, &MINT, &token_program_id, lower_bump);
+    assert!(!canonical_addr.is_on_curve());
+    assert!(!lower_bump_addr.is_on_curve());
+    let first_skipped_bump = lower_bump.checked_add(1).unwrap();
+    for skipped_bump in first_skipped_bump..canonical_bump {
+        assert!(
+            ata_address_with_bump(&wallet, &MINT, &token_program_id, skipped_bump).is_on_curve()
+        );
+    }
+
+    let mut harness = create_mint_account(&token_program_id);
+    harness.ensure_account_exists_with_lamports(wallet, 1_000_000);
+    harness.wallet = Some(wallet);
+    let mut instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: Some(lower_bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+    instruction.accounts[1] = AccountMeta::new(lower_bump_addr, false);
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::err(ProgramError::InvalidSeeds)]);
+}
+
+#[test]
+fn create_with_args_rejects_max_bump_hint_when_derived_address_mismatches_account() {
+    let token_program_id = spl_token_interface::id();
+    let mut harness = create_mint_account(&token_program_id);
+
+    let wallet = Address::from_str_const("931gKnvtYWR12hueG8Zb1yDigAntDghosriFUoK1Fr8P");
+    let (_, canonical_bump) = get_associated_token_address_and_bump_seed(
+        &wallet,
+        &MINT,
+        &spl_associated_token_account_interface::program::id(),
+        &token_program_id,
+    );
+
+    // This fixture keeps `u8::MAX` on-curve, so the higher-bump loop is skipped and
+    // rejection must come from the derived-address mismatch.
+    assert_eq!(canonical_bump, 253);
+    assert!(ata_address_with_bump(&wallet, &MINT, &token_program_id, 255).is_on_curve());
+
+    harness.ensure_account_exists_with_lamports(wallet, 1_000_000);
+    harness.wallet = Some(wallet);
+
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: Some(255),
+            account_len: None,
+            rent_sysvar: false,
+        });
+
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::err(ProgramError::InvalidSeeds)]);
+}
+
+#[test]
+fn create_with_args_rejects_canonical_bump_hint_for_wrong_ata_account() {
+    let token_program_id = spl_token_interface::id();
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&token_program_id, AtaProgram::Pinocchio)
+            .with_wallet_and_mint(1_000_000, 6);
+    let wallet = harness.wallet.unwrap();
+    let mint = harness.mint.unwrap();
+    let bump = expected_bump(&harness);
+
+    // The bump is canonical for this wallet/mint, but this account is not the ATA PDA derived
+    // from those seeds, so the address match must still fail.
+    let wrong_ata_account_addr = Address::new_unique();
+
+    harness.ctx.account_store.borrow_mut().insert(
+        wrong_ata_account_addr,
+        AccountBuilder::token_account(&mint, &wallet, 0, &token_program_id),
+    );
+
+    let mut instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Idempotent,
+            bump: Some(bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+    instruction.accounts[1] = AccountMeta::new(wrong_ata_account_addr, false);
+
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::err(ProgramError::InvalidSeeds)]);
+}
+
+#[test_case(CreateMode::Idempotent)]
+#[test_case(CreateMode::Always)]
+fn create_with_args_rejects_on_curve_bump_hint(mode: CreateMode) {
+    let token_program_id = spl_token_interface::id();
+    let mut harness = create_mint_account(&token_program_id);
+
+    let wallet = Address::from_str_const("931gKnvtYWR12hueG8Zb1yDigAntDghosriFUoK1Fr8P");
+
+    // The same wallet/mint with bump 254 derives this on-curve address
+    let on_curve_bump_addr =
+        Address::from_str_const("2XughgGgvRsf8VJiteF7ZEYF2jZbCTcTAFoEfrCfUXs7");
+
+    let canonical_bump = 253u8;
+    let attack_bump = canonical_bump.checked_add(1).unwrap();
+    let (_, actual_bump) = get_associated_token_address_and_bump_seed(
+        &wallet,
+        &MINT,
+        &spl_associated_token_account_interface::program::id(),
+        &token_program_id,
+    );
+    assert_eq!(actual_bump, canonical_bump);
+    assert_eq!(
+        ata_address_with_bump(&wallet, &MINT, &token_program_id, attack_bump),
+        on_curve_bump_addr
+    );
+    assert!(on_curve_bump_addr.is_on_curve());
+
+    harness.ensure_account_exists_with_lamports(wallet, 1_000_000);
+    harness.wallet = Some(wallet);
+
+    if mode == CreateMode::Idempotent {
+        harness.ctx.account_store.borrow_mut().insert(
+            on_curve_bump_addr,
+            AccountBuilder::token_account(&MINT, &wallet, 0, &token_program_id),
+        );
+    }
+    let mut instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode,
+            bump: Some(attack_bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+    instruction.accounts[1] = AccountMeta::new(on_curve_bump_addr, false);
+
+    match mode {
+        CreateMode::Idempotent => {
+            harness.ctx.process_and_validate_instruction(
+                &instruction,
+                &[Check::err(ProgramError::InvalidSeeds)],
+            );
+        }
+        CreateMode::Always => {
+            harness.ctx.process_and_validate_instruction(
+                &instruction,
+                &[Check::instruction_err(
+                    InstructionError::ProgramFailedToComplete,
+                )],
+            );
+        }
+    }
+}
+
+#[test_matrix(
+    [
+        (
+            255,
+            Address::from_str_const("1117mWrzzrZr312ebPDHu8tbfMwFNvCvMbr6WepCNG")
+        ),
+        (
+            253,
+            Address::from_str_const("931gKnvtYWR12hueG8Zb1yDigAntDghosriFUoK1Fr8P")
+        )
+    ],
+    [CreateMode::Always, CreateMode::Idempotent]
+)]
+fn create_with_args_accepts_canonical_bump_hint(bump_fixture: (u8, Address), mode: CreateMode) {
+    let token_program_id = spl_token_interface::id();
+    let mut harness = create_mint_account(&token_program_id);
+    let (expected_bump, wallet) = bump_fixture;
+    let (ata_address, canonical_bump) = get_associated_token_address_and_bump_seed(
+        &wallet,
+        &MINT,
+        &spl_associated_token_account_interface::program::id(),
+        &token_program_id,
+    );
+    assert_eq!(canonical_bump, expected_bump);
+    assert_eq!(
+        ata_address_with_bump(&wallet, &MINT, &token_program_id, canonical_bump),
+        ata_address
+    );
+    assert!(!ata_address.is_on_curve());
+
+    harness.ensure_account_exists_with_lamports(wallet, 1_000_000);
+    harness.wallet = Some(wallet);
+
+    if mode == CreateMode::Idempotent {
+        harness.ctx.account_store.borrow_mut().insert(
+            ata_address,
+            AccountBuilder::token_account(&MINT, &wallet, 0, &token_program_id),
+        );
+    }
+
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode,
+            bump: Some(canonical_bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[
+            Check::success(),
+            Check::account(&ata_address)
+                .space(spl_token_interface::state::Account::LEN)
+                .owner(&token_program_id)
+                .lamports(token_account_rent_exempt_balance())
+                .build(),
+        ],
+    );
+}
+
+#[test_matrix([spl_token_interface::id(), spl_token_2022_interface::id()])]
+fn create_with_args_idempotent_accepts_existing_ata_with_canonical_bump_hint(
+    token_program_id: Address,
+) {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&token_program_id, AtaProgram::Pinocchio)
+            .with_wallet_and_mint(1_000_000, 6);
+    let wallet = harness.wallet.unwrap();
+    let bump = expected_bump(&harness);
+    harness.insert_token_account_at_ata_address(wallet);
+
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Idempotent,
+            bump: Some(bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::success()]);
+}

--- a/pinocchio/program/tests/common.rs
+++ b/pinocchio/program/tests/common.rs
@@ -1,0 +1,16 @@
+use {
+    spl_associated_token_account_interface::address::get_associated_token_address_and_bump_seed,
+    spl_associated_token_account_mollusk_harness::AtaTestHarness,
+};
+
+pub fn expected_bump(harness: &AtaTestHarness) -> u8 {
+    let wallet = harness.wallet.unwrap();
+    let mint = harness.mint.unwrap();
+    let (_, bump) = get_associated_token_address_and_bump_seed(
+        &wallet,
+        &mint,
+        &spl_associated_token_account_interface::program::id(),
+        &harness.token_program_id,
+    );
+    bump
+}

--- a/pinocchio/program/tests/create_with_args.rs
+++ b/pinocchio/program/tests/create_with_args.rs
@@ -1,11 +1,13 @@
+mod common;
+
 use {
+    common::expected_bump,
     mollusk_svm_result::Check,
     pinocchio_associated_token_account_interface::instruction::CreateMode,
     solana_address::Address,
     solana_instruction::AccountMeta,
     solana_program_error::ProgramError,
     solana_program_pack::Pack,
-    spl_associated_token_account_interface::address::get_associated_token_address_and_bump_seed,
     spl_associated_token_account_mollusk_harness::{
         AtaProgram, AtaTestHarness, CreateAtaInstructionType,
         token_2022_immutable_owner_account_len, token_2022_immutable_owner_rent_exempt_balance,
@@ -13,18 +15,6 @@ use {
     },
     test_case::test_matrix,
 };
-
-fn expected_bump(harness: &AtaTestHarness) -> u8 {
-    let wallet = harness.wallet.unwrap();
-    let mint = harness.mint.unwrap();
-    let (_, bump) = get_associated_token_address_and_bump_seed(
-        &wallet,
-        &mint,
-        &spl_associated_token_account_interface::program::id(),
-        &harness.token_program_id,
-    );
-    bump
-}
 
 fn expected_account_len(token_program_id: &Address) -> usize {
     if *token_program_id == spl_token_2022_interface::id() {


### PR DESCRIPTION
Makes use of the `bump_hint` argument in the processor fn. When a hint is supplied, it is verified by checking that no higher bump produces an off-curve PDA rather than running `find_program_address`'s full descending search.

The savings is exactly one `is_on_curve()` call (~130 CU). Though take note of the idempotent-account-exists benchmark comment.