### PR TITLE
Wincode ix parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,9 @@ dependencies = [
  "codama-macros",
  "pinocchio 0.10.2 (git+https://github.com/anza-xyz/pinocchio?rev=0ca7555836700b31dae01ef6da37ef66df1831b8)",
  "solana-address 2.6.0",
+ "solana-nullable",
+ "solana-zero-copy",
+ "wincode 0.5.4",
 ]
 
 [[package]]
@@ -2705,7 +2708,7 @@ dependencies = [
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
- "wincode 0.5.1",
+ "wincode 0.5.4",
 ]
 
 [[package]]
@@ -3169,9 +3172,12 @@ dependencies = [
 
 [[package]]
 name = "solana-nullable"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da028344c595c7416769ff648d206de7962571291a4cea24c38a60b6f40d53bb"
+checksum = "a0f95d3028ef0f682bb174b77379c19d5dae2904a649f4a103fe29be7a139980"
+dependencies = [
+ "wincode 0.5.4",
+]
 
 [[package]]
 name = "solana-packet"
@@ -3780,9 +3786,12 @@ dependencies = [
 
 [[package]]
 name = "solana-zero-copy"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f52dd8f733a13f6a18e55de83cf97c4c3f5fdf27ea3830bcff0b35313efcc2"
+checksum = "c5a91404c7de468dd80658cdb5d894ec803d1092ea6e2bfdf84eee6f07559c0d"
+dependencies = [
+ "wincode 0.5.4",
+]
 
 [[package]]
 name = "solana-zk-sdk"
@@ -3898,6 +3907,7 @@ dependencies = [
  "spl-associated-token-account-interface 2.0.0",
  "spl-token-2022-interface",
  "spl-token-interface",
+ "wincode 0.5.4",
 ]
 
 [[package]]
@@ -4459,9 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "wincode"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f8f0a55eb6cae5d7b7ad2eca536a944deb9722a948525181069064ecd1abc"
+checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -4472,9 +4482,9 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca057fc9a13dd19cdb64ef558635d43c42667c0afa1ae7915ea1fa66993fd1a"
+checksum = "e262d55d1261f31e2cfe49cc6385a421d14d99faa0526bbe3cc1bda0d3005c62"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/mollusk_harness/Cargo.toml
+++ b/mollusk_harness/Cargo.toml
@@ -24,6 +24,7 @@ solana-system-interface = { version = "3.2", features = ["bincode"] }
 spl-associated-token-account-interface = { version = "2.0", path = "../interface" }
 spl-token-interface = "2.0"
 spl-token-2022-interface = "2.1"
+wincode = "0.5.4"
 
 mollusk-svm = { version = "0.12.0-agave-4.0", git = "https://github.com/anza-xyz/mollusk", branch = "agave-4.0" }
 mollusk-svm-programs-token = { version = "0.12.0-agave-4.0", git = "https://github.com/anza-xyz/mollusk", branch = "agave-4.0" }

--- a/mollusk_harness/src/lib.rs
+++ b/mollusk_harness/src/lib.rs
@@ -1,6 +1,8 @@
 use {
     mollusk_svm::{Mollusk, MolluskContext, result::Check},
-    pinocchio_associated_token_account_interface::instruction::CreateMode,
+    pinocchio_associated_token_account_interface::instruction::{
+        AccountLenHint, AssociatedTokenAccountInstruction, BumpSeedHint, CreateMode,
+    },
     solana_account::Account,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
@@ -635,30 +637,30 @@ impl AtaTestHarness {
 
 /// Encodes the instruction data payload for ATA creation-related instructions.
 pub fn encode_create_ata_instruction_data(instruction_type: &CreateAtaInstructionType) -> Vec<u8> {
-    match instruction_type {
-        CreateAtaInstructionType::Create => vec![0],
-        CreateAtaInstructionType::CreateIdempotent => vec![1],
+    let instruction = match instruction_type {
+        CreateAtaInstructionType::Create => AssociatedTokenAccountInstruction::Create,
+        CreateAtaInstructionType::CreateIdempotent => {
+            AssociatedTokenAccountInstruction::CreateIdempotent
+        }
         CreateAtaInstructionType::CreateWithArgs {
             mode,
             bump,
             account_len,
             ..
-        } => {
-            let mut data = vec![3, u8::from(*mode)];
-            match bump {
-                Some(bump) => data.extend_from_slice(&[1, *bump]),
-                None => data.push(0),
-            }
-            match account_len {
-                Some(account_len) => {
-                    data.push(1);
-                    data.extend_from_slice(&account_len.to_le_bytes());
-                }
-                None => data.push(0),
-            }
-            data
-        }
-    }
+        } => AssociatedTokenAccountInstruction::CreateWithArgs {
+            mode: *mode,
+            bump: bump
+                .and_then(BumpSeedHint::new)
+                .map(Into::into)
+                .unwrap_or_default(),
+            account_len: account_len
+                .and_then(AccountLenHint::new)
+                .map(Into::into)
+                .unwrap_or_default(),
+        },
+    };
+
+    wincode::serialize(&instruction).unwrap()
 }
 
 /// Build a create associated token account instruction with a given discriminator

--- a/pinocchio/interface/Cargo.toml
+++ b/pinocchio/interface/Cargo.toml
@@ -17,6 +17,9 @@ codama = ["dep:codama", "dep:codama-macros"]
 codama = { version = "0.9.2", optional = true }
 codama-macros = { version = "0.9.1", optional = true }
 solana-address = { version = "2.6.0", features = ["curve25519", "decode"] }
+solana-nullable = { version = "1.1.1", features = ["wincode"] }
+solana-zero-copy = { version = "1.0.1", features = ["wincode"] }
+wincode = { version = "0.5.4", default-features = false, features = ["derive"] }
 
 # TODO: Waiting on pinocchio crate publish
 pinocchio = { version = "0.10.1", git = "https://github.com/anza-xyz/pinocchio", rev = "0ca7555836700b31dae01ef6da37ef66df1831b8", default-features = false, features = ["cpi"] }

--- a/pinocchio/interface/idl.json
+++ b/pinocchio/interface/idl.json
@@ -391,34 +391,18 @@
             "kind": "instructionArgumentNode",
             "name": "bump",
             "type": {
-              "kind": "optionTypeNode",
-              "item": {
-                "kind": "numberTypeNode",
-                "format": "u8",
-                "endian": "le"
-              },
-              "prefix": {
-                "kind": "numberTypeNode",
-                "format": "u8",
-                "endian": "le"
-              }
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
             }
           },
           {
             "kind": "instructionArgumentNode",
             "name": "accountLen",
             "type": {
-              "kind": "optionTypeNode",
-              "item": {
-                "kind": "numberTypeNode",
-                "format": "u64",
-                "endian": "le"
-              },
-              "prefix": {
-                "kind": "numberTypeNode",
-                "format": "u8",
-                "endian": "le"
-              }
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
             }
           }
         ],

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -2,10 +2,17 @@
 
 #[cfg(feature = "codama")]
 use codama_macros::{CodamaInstructions, CodamaType};
+use {
+    pinocchio::error::ProgramError,
+    solana_nullable::{MaybeNull, Nullable},
+    solana_zero_copy::unaligned::U64,
+    wincode::{SchemaRead, SchemaWrite},
+};
 
 /// Instructions supported by the `AssociatedTokenAccount` program
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, SchemaRead, SchemaWrite)]
+#[wincode(tag_encoding = "u8")]
 #[cfg_attr(feature = "codama", derive(CodamaInstructions))]
 pub enum AssociatedTokenAccountInstruction {
     /// Creates an associated token account for the given wallet address and
@@ -181,26 +188,32 @@ pub enum AssociatedTokenAccountInstruction {
         /// Selects whether behaves like `Create` or `CreateIdempotent`.
         mode: CreateMode,
         /// The ATA PDA bump seed.
-        bump: Option<u8>,
+        #[cfg_attr(feature = "codama", codama(type = number(u8)))]
+        bump: MaybeNull<BumpSeedHint>,
         /// The account data length for the new ATA.
-        account_len: Option<u64>,
+        #[cfg_attr(feature = "codama", codama(type = number(u64)))]
+        account_len: MaybeNull<AccountLenHint>,
     },
 }
 
-impl From<AssociatedTokenAccountInstruction> for u8 {
-    fn from(value: AssociatedTokenAccountInstruction) -> Self {
-        match value {
-            AssociatedTokenAccountInstruction::Create => 0,
-            AssociatedTokenAccountInstruction::CreateIdempotent => 1,
-            AssociatedTokenAccountInstruction::RecoverNested => 2,
-            AssociatedTokenAccountInstruction::CreateWithArgs { .. } => 3,
+impl AssociatedTokenAccountInstruction {
+    #[inline(always)]
+    pub fn try_from_bytes(instruction_data: &[u8]) -> Result<Self, ProgramError> {
+        match instruction_data {
+            [] | [0] => Ok(Self::Create),
+            [1] => Ok(Self::CreateIdempotent),
+            [2] => Ok(Self::RecoverNested),
+            [3, ..] => wincode::deserialize_exact(instruction_data)
+                .map_err(|_| ProgramError::InvalidInstructionData),
+            _ => Err(ProgramError::InvalidInstructionData),
         }
     }
 }
 
 /// Specify when to create the associated token account.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, SchemaRead, SchemaWrite)]
+#[wincode(tag_encoding = "u8")]
 #[cfg_attr(feature = "codama", derive(CodamaType))]
 pub enum CreateMode {
     /// Always try to create the associated token account.
@@ -209,38 +222,154 @@ pub enum CreateMode {
     Idempotent = 1,
 }
 
-impl TryFrom<u8> for CreateMode {
-    type Error = ();
+/// The ATA PDA bump seed hint. `0` is reserved as the null value.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, SchemaRead, SchemaWrite)]
+#[wincode(assert_zero_copy)]
+pub struct BumpSeedHint(u8);
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::Always),
-            1 => Ok(Self::Idempotent),
-            _ => Err(()),
+impl BumpSeedHint {
+    /// Reserving `0` keeps the optional bump hint as a single zero-copy byte in the wire format,
+    /// without an extra option tag. A PDA bump of `0` is valid but very unlikely. The tradeoff
+    /// is that it forfeits the bump-hint optimization for that rare case.
+    pub const fn new(value: u8) -> Option<Self> {
+        if value == 0 { None } else { Some(Self(value)) }
+    }
+}
+
+impl Nullable for BumpSeedHint {
+    const NONE: Self = Self(0);
+}
+
+impl From<BumpSeedHint> for u8 {
+    fn from(value: BumpSeedHint) -> Self {
+        value.0
+    }
+}
+
+/// The account data length hint for the new ATA. `0` is reserved as the null value.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, SchemaRead, SchemaWrite)]
+#[wincode(assert_zero_copy)]
+pub struct AccountLenHint(U64);
+
+impl AccountLenHint {
+    pub const fn new(value: u64) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Some(Self(U64::from_primitive(value)))
         }
     }
 }
 
-impl From<CreateMode> for u8 {
-    fn from(value: CreateMode) -> Self {
-        value as u8
+impl Nullable for AccountLenHint {
+    const NONE: Self = Self(U64::from_primitive(0));
+}
+
+impl From<AccountLenHint> for u64 {
+    fn from(value: AccountLenHint) -> Self {
+        value.0.into()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::AssociatedTokenAccountInstruction;
+    use {
+        super::{AccountLenHint, AssociatedTokenAccountInstruction, BumpSeedHint, CreateMode},
+        pinocchio::error::ProgramError,
+        solana_nullable::{MaybeNull, Nullable},
+        wincode::Serialize,
+    };
+
+    fn assert_wire<const N: usize>(
+        instruction: AssociatedTokenAccountInstruction,
+        expected: [u8; N],
+    ) {
+        let mut bytes = [0; N];
+        AssociatedTokenAccountInstruction::serialize_into(bytes.as_mut_slice(), &instruction)
+            .unwrap();
+        assert_eq!(bytes, expected);
+        assert_eq!(
+            AssociatedTokenAccountInstruction::try_from_bytes(&expected).unwrap(),
+            instruction
+        );
+        let decoded: AssociatedTokenAccountInstruction =
+            wincode::deserialize_exact(&expected).unwrap();
+        assert_eq!(decoded, instruction);
+    }
 
     #[test]
-    fn discriminants_match_legacy_layout() {
-        assert_eq!(u8::from(AssociatedTokenAccountInstruction::Create), 0);
-        assert_eq!(
-            u8::from(AssociatedTokenAccountInstruction::CreateIdempotent),
-            1
+    fn instruction_wire_format_is_stable() {
+        assert_wire(AssociatedTokenAccountInstruction::Create, [0]);
+        assert_wire(AssociatedTokenAccountInstruction::CreateIdempotent, [1]);
+        assert_wire(AssociatedTokenAccountInstruction::RecoverNested, [2]);
+        assert_wire(
+            AssociatedTokenAccountInstruction::CreateWithArgs {
+                mode: CreateMode::Always,
+                bump: MaybeNull::from(BumpSeedHint::NONE),
+                account_len: MaybeNull::from(AccountLenHint::NONE),
+            },
+            [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         );
-        assert_eq!(
-            u8::from(AssociatedTokenAccountInstruction::RecoverNested),
-            2
+        assert_wire(
+            AssociatedTokenAccountInstruction::CreateWithArgs {
+                mode: CreateMode::Idempotent,
+                bump: BumpSeedHint::new(253).unwrap().into(),
+                account_len: MaybeNull::from(AccountLenHint::NONE),
+            },
+            [3, 1, 253, 0, 0, 0, 0, 0, 0, 0, 0],
         );
+        assert_wire(
+            AssociatedTokenAccountInstruction::CreateWithArgs {
+                mode: CreateMode::Always,
+                bump: MaybeNull::from(BumpSeedHint::NONE),
+                account_len: AccountLenHint::new(u64::from_le_bytes([1, 2, 3, 4, 5, 6, 7, 8]))
+                    .unwrap()
+                    .into(),
+            },
+            [3, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8],
+        );
+        assert_wire(
+            AssociatedTokenAccountInstruction::CreateWithArgs {
+                mode: CreateMode::Idempotent,
+                bump: BumpSeedHint::new(253).unwrap().into(),
+                account_len: AccountLenHint::new(u64::from_le_bytes([1, 2, 3, 4, 5, 6, 7, 8]))
+                    .unwrap()
+                    .into(),
+            },
+            [3, 1, 253, 1, 2, 3, 4, 5, 6, 7, 8],
+        );
+    }
+
+    #[test]
+    fn empty_instruction_data_remains_create() {
+        assert_eq!(
+            AssociatedTokenAccountInstruction::try_from_bytes(&[]).unwrap(),
+            AssociatedTokenAccountInstruction::Create
+        );
+    }
+
+    #[test]
+    fn instruction_parser_rejects_non_canonical_payloads() {
+        let cases: &[&[u8]] = &[
+            &[4],                                  // unknown discriminator
+            &[0, 0],                               // trailing byte after Create
+            &[1, 9, 9],                            // trailing bytes after CreateIdempotent
+            &[2, 0],                               // trailing byte after RecoverNested
+            &[3],                                  // missing CreateWithArgs mode
+            &[3, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],    // invalid CreateWithArgs mode
+            &[3, 0],                               // missing bump hint
+            &[3, 0, 0],                            // missing account_len hint
+            &[3, 0, 0, 0, 0, 0, 0, 0, 0, 0],       // truncated account_len hint
+            &[3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], // trailing byte after CreateWithArgs
+        ];
+
+        for data in cases {
+            assert_eq!(
+                AssociatedTokenAccountInstruction::try_from_bytes(data),
+                Err(ProgramError::InvalidInstructionData)
+            );
+        }
     }
 }

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -230,7 +230,7 @@ pub struct BumpSeedHint(u8);
 
 impl BumpSeedHint {
     /// Reserving `0` keeps the optional bump hint as a single zero-copy byte in the wire format,
-    /// without an extra option tag. A PDA bump of `0` is valid but very unlikely. The tradeoff
+    /// without an extra option tag. A PDA bump of `0` is valid but very unlikely. The trade-off
     /// is that it forfeits the bump-hint optimization for that rare case.
     pub const fn new(value: u8) -> Option<Self> {
         if value == 0 { None } else { Some(Self(value)) }

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,30 @@
+#### 2026-05-15 13:10:10.319363 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3221 | -- |
+| create_with_args (spl-token) | 3155 | -14 |
+| create (token-2022) | 5265 | +1 |
+| create_with_args (token-2022) | 5198 | -15 |
+| create_idempotent (new, spl-token) | 4314 | -- |
+| create_with_args_idempotent (new, spl-token) | 4247 | -16 |
+| create_idempotent (new, token-2022) | 5634 | -- |
+| create_with_args_idempotent (new, token-2022) | 5566 | -17 |
+| create_idempotent (existing, spl-token) | 561 | -- |
+| create_with_args_idempotent (existing, spl-token) | 577 | -16 |
+| create_idempotent (existing, token-2022) | 1647 | -- |
+| create_with_args_idempotent (existing, token-2022) | 1663 | -16 |
+| create (prefunded, spl-token) | 3221 | -- |
+| create_with_args (prefunded, spl-token) | 3155 | -14 |
+| create (prefunded, token-2022) | 5265 | +1 |
+| create_with_args (prefunded, token-2022) | 5198 | -15 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5243 | -- |
+| recover_nested (owner=token-2022, nested=token-2022) | 7107 | -- |
+| recover_nested (owner=spl-token, nested=token-2022) | 9663 | -- |
+| recover_nested (owner=token-2022, nested=spl-token) | 5613 | -- |
+
 #### 2026-05-12 22:54:18.923148 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/benches/compute_units.rs
+++ b/pinocchio/program/benches/compute_units.rs
@@ -19,6 +19,9 @@ use {
         },
         program::id as ata_program_id,
     },
+    spl_associated_token_account_mollusk_harness::{
+        CreateAtaInstructionType, encode_create_ata_instruction_data,
+    },
     spl_token_2022_interface::extension::ExtensionType,
     spl_token_interface::state::{Account as TokenAccount, AccountState, Mint},
     std::path::PathBuf,
@@ -39,8 +42,12 @@ fn create_associated_token_account_with_args(
         &ata_program_id(),
         token_program_id,
     );
-    let mut data = vec![3, u8::from(mode), 1, bump, 1];
-    data.extend_from_slice(&account_len.to_le_bytes());
+    let data = encode_create_ata_instruction_data(&CreateAtaInstructionType::CreateWithArgs {
+        mode,
+        bump: Some(bump),
+        account_len: Some(account_len),
+        rent_sysvar: true,
+    });
 
     Instruction {
         program_id: ata_program_id(),

--- a/pinocchio/program/src/processor.rs
+++ b/pinocchio/program/src/processor.rs
@@ -1,6 +1,6 @@
 use {
     crate::{create::process_create_associated_token_account, recover::process_recover_nested},
-    pinocchio::{AccountView, Address, ProgramResult, error::ProgramError},
+    pinocchio::{AccountView, Address, ProgramResult},
     pinocchio_associated_token_account_interface::instruction::{
         AssociatedTokenAccountInstruction, CreateMode,
     },
@@ -12,7 +12,7 @@ pub fn process_instruction(
     accounts: &mut [AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
-    match parse_instruction(instruction_data)? {
+    match AssociatedTokenAccountInstruction::try_from_bytes(instruction_data)? {
         AssociatedTokenAccountInstruction::Create => process_create_associated_token_account(
             program_id,
             accounts,
@@ -40,149 +40,11 @@ pub fn process_instruction(
             accounts,
             mode,
             true,
-            bump,
-            account_len,
+            bump.get().map(Into::into),
+            account_len.get().map(Into::into),
         ),
         AssociatedTokenAccountInstruction::RecoverNested => {
             process_recover_nested(program_id, accounts)
-        }
-    }
-}
-
-/// Canonical ATA instruction format:
-/// - `[]` or `[0]`: `Create`
-/// - `[1]`: `CreateIdempotent`
-/// - `[2]`: `RecoverNested`
-/// - `[3, mode, bump_tag, bump?, account_len_tag, account_len?]`: `CreateWithArgs`
-/// - any other payload is invalid
-#[inline(always)]
-fn parse_instruction(
-    instruction_data: &[u8],
-) -> Result<AssociatedTokenAccountInstruction, ProgramError> {
-    match instruction_data {
-        [] | [0] => Ok(AssociatedTokenAccountInstruction::Create),
-        [1] => Ok(AssociatedTokenAccountInstruction::CreateIdempotent),
-        [2] => Ok(AssociatedTokenAccountInstruction::RecoverNested),
-        [3, mode, create_args @ ..] => {
-            let (bump, account_len) = parse_create_args(create_args)?;
-            Ok(AssociatedTokenAccountInstruction::CreateWithArgs {
-                mode: CreateMode::try_from(*mode)
-                    .map_err(|_| ProgramError::InvalidInstructionData)?,
-                bump,
-                account_len,
-            })
-        }
-        _ => Err(ProgramError::InvalidInstructionData),
-    }
-}
-
-#[inline(always)]
-fn parse_create_args(create_args: &[u8]) -> Result<(Option<u8>, Option<u64>), ProgramError> {
-    let (bump, rest) = match create_args {
-        [0, rest @ ..] => (None, rest),
-        [1, bump, rest @ ..] => (Some(*bump), rest),
-        _ => return Err(ProgramError::InvalidInstructionData),
-    };
-
-    let account_len = match rest {
-        [0] => None,
-        [1, bytes @ ..] => Some(u64::from_le_bytes(
-            bytes
-                .try_into()
-                .map_err(|_| ProgramError::InvalidInstructionData)?,
-        )),
-        _ => return Err(ProgramError::InvalidInstructionData),
-    };
-
-    Ok((bump, account_len))
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::{ProgramError, parse_instruction},
-        pinocchio_associated_token_account_interface::instruction::{
-            AssociatedTokenAccountInstruction, CreateMode,
-        },
-    };
-
-    #[test]
-    fn parse_instruction_matches_ata_wire_format() {
-        assert_eq!(
-            parse_instruction(&[]).unwrap(),
-            AssociatedTokenAccountInstruction::Create
-        );
-        assert_eq!(
-            parse_instruction(&[0]).unwrap(),
-            AssociatedTokenAccountInstruction::Create
-        );
-        assert_eq!(
-            parse_instruction(&[1]).unwrap(),
-            AssociatedTokenAccountInstruction::CreateIdempotent
-        );
-        assert_eq!(
-            parse_instruction(&[2]).unwrap(),
-            AssociatedTokenAccountInstruction::RecoverNested
-        );
-        assert_eq!(
-            parse_instruction(&[3, 0, 0, 0]).unwrap(),
-            AssociatedTokenAccountInstruction::CreateWithArgs {
-                mode: CreateMode::Always,
-                bump: None,
-                account_len: None,
-            }
-        );
-        assert_eq!(
-            parse_instruction(&[3, 1, 1, 253, 0]).unwrap(),
-            AssociatedTokenAccountInstruction::CreateWithArgs {
-                mode: CreateMode::Idempotent,
-                bump: Some(253),
-                account_len: None,
-            }
-        );
-        assert_eq!(
-            parse_instruction(&[3, 0, 0, 1, 1, 2, 3, 4, 5, 6, 7, 8]).unwrap(),
-            AssociatedTokenAccountInstruction::CreateWithArgs {
-                mode: CreateMode::Always,
-                bump: None,
-                account_len: Some(u64::from_le_bytes([1, 2, 3, 4, 5, 6, 7, 8])),
-            }
-        );
-        assert_eq!(
-            parse_instruction(&[3, 1, 1, 253, 1, 1, 2, 3, 4, 5, 6, 7, 8]).unwrap(),
-            AssociatedTokenAccountInstruction::CreateWithArgs {
-                mode: CreateMode::Idempotent,
-                bump: Some(253),
-                account_len: Some(u64::from_le_bytes([1, 2, 3, 4, 5, 6, 7, 8])),
-            }
-        );
-    }
-
-    #[test]
-    fn parse_instruction_rejects_non_canonical_payloads() {
-        let cases: &[&[u8]] = &[
-            &[4],                                       // unknown discriminator
-            &[0, 0],                                    // trailing byte after Create
-            &[1, 9, 9],                                 // trailing bytes after CreateIdempotent
-            &[3],                                       // missing CreateWithArgs mode
-            &[3, 2, 0, 0],                              // invalid CreateWithArgs mode
-            &[3, 1],                                    // missing bump tag
-            &[3, 1, 0],                                 // missing account_len tag
-            &[3, 1, 2, 0],                              // invalid bump tag
-            &[3, 1, 1],                                 // bump tag present without bump
-            &[3, 1, 1, 253],                            // missing account_len tag after bump
-            &[3, 1, 0, 2],                              // invalid account_len tag
-            &[3, 1, 0, 1],                              // account_len tag without account_len
-            &[3, 1, 0, 1, 165, 0, 0, 0, 0, 0, 0],       // truncated account_len
-            &[3, 1, 0, 1, 165, 0, 0, 0, 0, 0, 0, 0, 0], // trailing byte after account_len
-            &[3, 1, 0, 0, 0],                           // trailing byte after CreateWithArgs
-            &[2, 0],                                    // trailing byte after RecoverNested
-        ];
-        for data in cases {
-            assert_eq!(
-                parse_instruction(data),
-                Err(ProgramError::InvalidInstructionData)
-            );
         }
     }
 }

--- a/pinocchio/program/tests/recover_nested.rs
+++ b/pinocchio/program/tests/recover_nested.rs
@@ -1,6 +1,5 @@
 use {
     mollusk_svm_result::Check,
-    pinocchio_associated_token_account_interface::instruction::AssociatedTokenAccountInstruction,
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
@@ -54,7 +53,7 @@ fn recover_nested_ix(
             AccountMeta::new_readonly(owner_token_program_id, false),
             AccountMeta::new_readonly(nested_token_program_id, false),
         ],
-        data: vec![u8::from(AssociatedTokenAccountInstruction::RecoverNested)],
+        data: vec![2],
     }
 }
 


### PR DESCRIPTION
This updates the p-ATA instruction parsing to use `wincode` for `CreateWithArgs`. This comes with a change to the wire format. Instead of option-tagged fields, its optional optimization hints now use null-sentinel values for `bump` and `account_len` (zero means null).