### PR TITLE
p-ata: Use latest platform tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ rust-toolchain-nightly:
 solana-cli-version:
 	@echo ${SOLANA_CLI_VERSION}
 
-platform-tools-version:
-	@echo ${PLATFORM_TOOLS_VERSION}
-
 cargo-nightly:
 	cargo $(nightly) $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 RUST_TOOLCHAIN_NIGHTLY = nightly-2026-01-22
 SOLANA_CLI_VERSION = 3.1.8
+PLATFORM_TOOLS_VERSION = 1.54
 
 nightly = +${RUST_TOOLCHAIN_NIGHTLY}
 
@@ -92,7 +93,7 @@ mollusk run-test \
 endef
 
 regression-%:
-	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml
+	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml --tools-version $(PLATFORM_TOOLS_VERSION)
 	$(call run-mollusk-regression,$*,program/tests/fixtures/spl_token_2022.so,pinocchio/program/fuzz/blob)
 	$(call run-mollusk-regression,$*,program/tests/fixtures/mock_token_program.so,pinocchio/program/fuzz/blob-mock)
 
@@ -100,7 +101,7 @@ format-rust:
 	cargo $(nightly) fmt --all $(ARGS)
 
 build-sbf-%:
-	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)
+	cargo build-sbf --manifest-path $(call make-path,$*)/Cargo.toml --tools-version $(PLATFORM_TOOLS_VERSION) $(ARGS)
 
 build-wasm-%:
 	cargo build --target wasm32-unknown-unknown --manifest-path $(call make-path,$*)/Cargo.toml --all-features $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ rust-toolchain-nightly:
 solana-cli-version:
 	@echo ${SOLANA_CLI_VERSION}
 
+platform-tools-version:
+	@echo ${PLATFORM_TOOLS_VERSION}
+
 cargo-nightly:
 	cargo $(nightly) $(ARGS)
 

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,30 @@
+#### 2026-05-16 09:50:42.971998 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3207 | -14 |
+| create_with_args (spl-token) | 3147 | -10 |
+| create (token-2022) | 5245 | -19 |
+| create_with_args (token-2022) | 5184 | -17 |
+| create_idempotent (new, spl-token) | 4298 | -16 |
+| create_with_args_idempotent (new, spl-token) | 4237 | -12 |
+| create_idempotent (new, token-2022) | 5612 | -22 |
+| create_with_args_idempotent (new, token-2022) | 5550 | -19 |
+| create_idempotent (existing, spl-token) | 548 | -13 |
+| create_with_args_idempotent (existing, spl-token) | 567 | -12 |
+| create_idempotent (existing, token-2022) | 1634 | -13 |
+| create_with_args_idempotent (existing, token-2022) | 1653 | -12 |
+| create (prefunded, spl-token) | 3207 | -14 |
+| create_with_args (prefunded, spl-token) | 3147 | -10 |
+| create (prefunded, token-2022) | 5245 | -19 |
+| create_with_args (prefunded, token-2022) | 5184 | -17 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5192 | -51 |
+| recover_nested (owner=token-2022, nested=token-2022) | 7056 | -51 |
+| recover_nested (owner=spl-token, nested=token-2022) | 9612 | -51 |
+| recover_nested (owner=token-2022, nested=spl-token) | 5562 | -51 |
+
 #### 2026-05-15 22:33:38.576197 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)


### PR DESCRIPTION
### Problem

Platform tools version 1.52 and 1.53 had performance regressions. These were fixed in 1.54, but it is not the version currently being used.

### Solution

Add a `PLATFORM_TOOLS_VERSION` variable to the makefile to allow specifying the version to use. The advantage is that this is independent of the Solana CLI version, so it is more reliable to reproduce the results for the bench.

Using the latest platform tools shows double-digit improvements in CUs.