### PR TITLE
p-ata: account_len hint

### DIFF
--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,31 @@
+#### 2026-05-19 22:40:12.433847 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3201 | -7 |
+| create_with_args (spl-token) | 3010 | -3 |
+| create (token-2022) | 5250 | +4 |
+| create_with_args (token-2022) | 5053 | +2 |
+| create_idempotent (new, spl-token) | 4289 | -11 |
+| create_with_args_idempotent (new, spl-token) | 4103 | -3 |
+| create_idempotent (new, token-2022) | 5614 | +1 |
+| create_with_args_idempotent (new, token-2022) | 5422 | +2 |
+| create_idempotent (existing, spl-token) | 548 | -- |
+| create_with_args_idempotent (existing, spl-token) | 606 | +1 |
+| create_idempotent (existing, token-2022) | 1634 | -- |
+| create_with_args_idempotent (existing, token-2022) | 1695 | +1 |
+| create (prefunded, spl-token) | 3201 | -7 |
+| create_with_args (prefunded, spl-token) | 3010 | -3 |
+| create (prefunded, token-2022) | 5250 | +4 |
+| create_with_args (prefunded, token-2022) | 5053 | +2 |
+| create_with_args (token-2022 extended mint) | 5869 | -2,545 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5191 | -- |
+| recover_nested (owner=token-2022, nested=token-2022) | 7055 | -- |
+| recover_nested (owner=spl-token, nested=token-2022) | 9611 | -- |
+| recover_nested (owner=token-2022, nested=spl-token) | 5561 | -- |
+
 #### 2026-05-19 02:45:39.155444 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
@@ -20,6 +48,7 @@ Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agav
 | create_with_args (prefunded, spl-token) | 3013 | -134 |
 | create (prefunded, token-2022) | 5246 | +1 |
 | create_with_args (prefunded, token-2022) | 5051 | -133 |
+| create_with_args (token-2022 extended mint) | 8414 | - new - |
 | recover_nested (owner=spl-token, nested=spl-token) | 5191 | -1 |
 | recover_nested (owner=token-2022, nested=token-2022) | 7055 | -1 |
 | recover_nested (owner=spl-token, nested=token-2022) | 9611 | -1 |

--- a/pinocchio/program/benches/compute_units.rs
+++ b/pinocchio/program/benches/compute_units.rs
@@ -22,7 +22,13 @@ use {
     spl_associated_token_account_mollusk_harness::{
         CreateAtaInstructionType, encode_create_ata_instruction_data,
     },
-    spl_token_2022_interface::extension::ExtensionType,
+    spl_token_2022_interface::{
+        extension::{
+            BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut,
+            transfer_fee::TransferFeeConfig,
+        },
+        state::Mint as Token2022Mint,
+    },
     spl_token_interface::state::{Account as TokenAccount, AccountState, Mint},
     std::path::PathBuf,
 };
@@ -223,7 +229,6 @@ fn main() {
         spl_token_2022_interface::state::Account,
     >(&[ExtensionType::ImmutableOwner])
     .unwrap() as u32;
-
     // Bench 1: create (spl-token)
     let wallet1 = Address::new_unique();
     let ata1 = get_associated_token_address_with_program_id(
@@ -512,7 +517,66 @@ fn main() {
     let mut accs5b_create_with_args = accs5b.clone();
     accs5b_create_with_args.push(rent_sysvar.clone());
 
-    // Benches 11-14: recover_nested
+    let t22_extended_mint = Address::new_unique();
+    let t22_extended_mint_space = ExtensionType::try_calculate_account_len::<Token2022Mint>(&[
+        ExtensionType::TransferFeeConfig,
+    ])
+    .unwrap();
+    let mut t22_extended_mint_data = vec![0; t22_extended_mint_space];
+    let mut state =
+        StateWithExtensionsMut::<Token2022Mint>::unpack_uninitialized(&mut t22_extended_mint_data)
+            .unwrap();
+    state.init_extension::<TransferFeeConfig>(true).unwrap();
+    state.base = Token2022Mint {
+        mint_authority: COption::Some(mint_authority),
+        supply: 1_000_000,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    };
+    state.pack_base();
+    state.init_account_type().unwrap();
+    let t22_extended_mint_account = Account {
+        lamports: solana_rent::Rent::default().minimum_balance(t22_extended_mint_space),
+        data: t22_extended_mint_data,
+        owner: spl_token_2022_interface::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let wallet2_extended = Address::new_unique();
+    let ata2_extended = get_associated_token_address_with_program_id(
+        &wallet2_extended,
+        &t22_extended_mint,
+        &spl_token_2022_interface::id(),
+    );
+    let accs2_extended = vec![
+        (payer, payer_account.clone()),
+        (ata2_extended, Account::default()),
+        (
+            wallet2_extended,
+            Account::new(1_000_000, 0, &system_program::id()),
+        ),
+        (t22_extended_mint, t22_extended_mint_account.clone()),
+        system_account.clone(),
+        t22_account.clone(),
+    ];
+    let ix2_extended_create_with_args = create_associated_token_account_with_args(
+        &payer,
+        &wallet2_extended,
+        &t22_extended_mint,
+        &spl_token_2022_interface::id(),
+        &rent_sysvar.0,
+        CreateMode::Always,
+        ExtensionType::try_calculate_account_len::<spl_token_2022_interface::state::Account>(&[
+            ExtensionType::ImmutableOwner,
+            ExtensionType::TransferFeeAmount,
+        ])
+        .unwrap() as u32,
+    );
+    let mut accs2_extended_create_with_args = accs2_extended.clone();
+    accs2_extended_create_with_args.push(rent_sysvar.clone());
+
+    // recover_nested benches
     let (ix6, accs6) = recover_nested_case(
         Address::new_from_array([1; 32]),
         Address::new_from_array([2; 32]),
@@ -598,6 +662,11 @@ fn main() {
             "create_with_args (prefunded, token-2022)",
             &ix5b_create_with_args,
             &accs5b_create_with_args,
+        ))
+        .bench((
+            "create_with_args (token-2022 extended mint)",
+            &ix2_extended_create_with_args,
+            &accs2_extended_create_with_args,
         ))
         .bench((
             "recover_nested (owner=spl-token, nested=spl-token)",

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{batch::batch_init_and_lock_owner, size::get_account_data_size},
+    crate::{batch::batch_init_and_lock_owner, size::get_t22_account_data_size},
     pinocchio::{
         AccountView, Address, ProgramResult, cpi::Signer, error::ProgramError, instruction::seeds,
     },
@@ -18,7 +18,7 @@ pub(crate) fn process_create_associated_token_account(
     create_mode: CreateMode,
     accept_rent_sysvar: bool,
     bump_hint: Option<u8>,
-    _account_len_hint: Option<u32>,
+    account_len_hint: Option<u32>,
 ) -> ProgramResult {
     let [
         payer,
@@ -100,7 +100,20 @@ pub(crate) fn process_create_associated_token_account(
         return Err(ProgramError::IllegalOwner);
     }
 
-    let account_len = get_account_data_size(mint, token_program)?;
+    let is_spl_token = *token_program.address() == pinocchio_token::ID;
+    let account_len = if is_spl_token {
+        TokenAccount::BASE_LEN as u64
+    } else if *token_program.address() == pinocchio_token_2022::ID {
+        // Undersized accounts fail during initialization and excessive sizes fail
+        // through rent/system account-size limits.
+        if let Some(account_len_hint) = account_len_hint {
+            account_len_hint as u64
+        } else {
+            get_t22_account_data_size(mint, token_program)?
+        }
+    } else {
+        return Err(ProgramError::IncorrectProgramId);
+    };
 
     // Create the PDA (handles pre-funded accounts)
     let bump_ref = &[bump_seed];
@@ -121,7 +134,7 @@ pub(crate) fn process_create_associated_token_account(
     .invoke_signed(&[signer])?;
 
     // If token-2022, lock the owner field
-    if *token_program.address() != pinocchio_token::ID {
+    if !is_spl_token {
         batch_init_and_lock_owner(
             token_program.address(),
             associated_token_account,

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{batch::batch_init_and_lock_owner, size::get_t22_account_data_size},
+    crate::{batch::batch_init_and_lock_owner, size::get_token_2022_account_data_size},
     pinocchio::{
         AccountView, Address, ProgramResult, cpi::Signer, error::ProgramError, instruction::seeds,
     },
@@ -109,7 +109,7 @@ pub(crate) fn process_create_associated_token_account(
         if let Some(account_len_hint) = account_len_hint {
             account_len_hint as u64
         } else {
-            get_t22_account_data_size(mint, token_program)?
+            get_token_2022_account_data_size(mint, token_program)?
         }
     } else {
         return Err(ProgramError::IncorrectProgramId);

--- a/pinocchio/program/src/size.rs
+++ b/pinocchio/program/src/size.rs
@@ -27,7 +27,7 @@ const TOKEN_2022_BASE_ACCOUNT_DATA_SIZE: u64 =
 /// Short-circuits when size is known and falls back to `GetAccountDataSize` CPI for
 /// everything else.
 #[inline(always)]
-pub(crate) fn get_t22_account_data_size(
+pub(crate) fn get_token_2022_account_data_size(
     mint: &AccountView,
     token_program: &AccountView,
 ) -> Result<u64, ProgramError> {

--- a/pinocchio/program/src/size.rs
+++ b/pinocchio/program/src/size.rs
@@ -23,33 +23,23 @@ const TLV_HEADER_LEN: usize = 4;
 const TOKEN_2022_BASE_ACCOUNT_DATA_SIZE: u64 =
     TokenAccount::BASE_LEN as u64 + ACCOUNT_TYPE_SIZE as u64 + TLV_HEADER_LEN as u64;
 
-/// Get the required account data size for an ATA with the `ImmutableOwner` extension.
-/// Short-circuits for the two common cases (SPL Token, Token-2022 with no mint
-/// extensions) and falls back to a `GetAccountDataSize` CPI for everything else.
+/// Get the required Token-2022 account data size when no account length hint was supplied.
+/// Short-circuits when size is known and falls back to `GetAccountDataSize` CPI for
+/// everything else.
 #[inline(always)]
-pub(crate) fn get_account_data_size(
+pub(crate) fn get_t22_account_data_size(
     mint: &AccountView,
     token_program: &AccountView,
 ) -> Result<u64, ProgramError> {
-    // SPL Token accounts are always exactly 165 bytes.
-    if *token_program.address() == pinocchio_token::ID {
-        return Ok(TokenAccount::BASE_LEN as u64);
+    // Associated token accounts for Token-2022 always enable `ImmutableOwner`.
+    // If the mint is exactly Mint::BASE_LEN, it has no mint extensions. In that case,
+    // the new account only needs the base token account layout plus the
+    // zero-length `ImmutableOwner` extension.
+    if mint.data_len() == Mint::BASE_LEN {
+        return Ok(TOKEN_2022_BASE_ACCOUNT_DATA_SIZE);
     }
 
-    if *token_program.address() == pinocchio_token_2022::ID {
-        // Associated token accounts for Token-2022 always enable `ImmutableOwner`.
-        // If the mint is exactly Mint::BASE_LEN, it has no mint extensions. In that case,
-        // the new account only needs the base token account layout plus the
-        // zero-length `ImmutableOwner` extension.
-        if mint.data_len() == Mint::BASE_LEN {
-            return Ok(TOKEN_2022_BASE_ACCOUNT_DATA_SIZE);
-        }
-
-        return get_account_data_size_cpi(mint, token_program);
-    }
-
-    // Only SPL Token and Token-2022 are allowed
-    Err(ProgramError::IncorrectProgramId)
+    get_account_data_size_cpi(mint, token_program)
 }
 
 fn get_account_data_size_cpi(

--- a/pinocchio/program/tests/account_len.rs
+++ b/pinocchio/program/tests/account_len.rs
@@ -1,0 +1,248 @@
+use {
+    mollusk_svm_result::Check,
+    pinocchio_associated_token_account_interface::instruction::CreateMode,
+    solana_address::Address,
+    solana_program_error::ProgramError,
+    solana_program_pack::Pack,
+    solana_rent::Rent,
+    spl_associated_token_account_mollusk_harness::{
+        AtaProgram, AtaTestHarness, CreateAtaInstructionType,
+        token_2022_immutable_owner_account_len, token_account_rent_exempt_balance,
+    },
+    spl_token_2022_interface::{extension::ExtensionType, state::Account as Token2022Account},
+    test_case::{test_case, test_matrix},
+};
+
+fn token_2022_harness(transfer_fee_mint: bool) -> AtaTestHarness {
+    let harness = AtaTestHarness::new_with_ata_program(
+        &spl_token_2022_interface::id(),
+        AtaProgram::Pinocchio,
+    );
+
+    if transfer_fee_mint {
+        harness
+            .with_wallet(1_000_000)
+            .with_mint_with_extensions(&[ExtensionType::TransferFeeConfig])
+            .initialize_transfer_fee(1_000, 100)
+            .initialize_mint(0)
+    } else {
+        harness.with_wallet_and_mint(1_000_000, 6)
+    }
+}
+
+fn token_2022_required_account_len(transfer_fee_mint: bool) -> usize {
+    if transfer_fee_mint {
+        ExtensionType::try_calculate_account_len::<Token2022Account>(&[
+            ExtensionType::ImmutableOwner,
+            ExtensionType::TransferFeeAmount,
+        ])
+        .unwrap()
+    } else {
+        token_2022_immutable_owner_account_len()
+    }
+}
+
+#[test_matrix([spl_token_interface::id(), spl_token_2022_interface::id()], [1, u32::MAX])]
+fn idempotent_existing_ata_ignores_hint(token_program_id: Address, account_len: u32) {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&token_program_id, AtaProgram::Pinocchio)
+            .with_wallet_and_mint(1_000_000, 6);
+    let wallet = harness.wallet.unwrap();
+    harness.insert_token_account_at_ata_address(wallet);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Idempotent,
+            bump: None,
+            account_len: Some(account_len),
+            rent_sysvar: false,
+        });
+
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::success()]);
+}
+
+#[test]
+fn always_mode_with_existing_ata_fails_before_hint_check() {
+    let mut harness = token_2022_harness(false);
+    let wallet = harness.wallet.unwrap();
+    harness.insert_token_account_at_ata_address(wallet);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: Some(u32::MAX),
+            rent_sysvar: false,
+        });
+
+    // u32::MAX would fail with InvalidArgument if the hint were checked first.
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::err(ProgramError::IllegalOwner)]);
+}
+
+#[test_matrix(
+    [CreateMode::Always, CreateMode::Idempotent],
+    [1, spl_token_interface::state::Account::LEN as u32, u32::MAX]
+)]
+fn spl_token_always_allocates_165_bytes_ignoring_hint(mode: CreateMode, account_len_hint: u32) {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&spl_token_interface::id(), AtaProgram::Pinocchio)
+            .with_wallet_and_mint(1_000_000, 6);
+    let account_len = spl_token_interface::state::Account::LEN;
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode,
+            bump: None,
+            account_len: Some(account_len_hint),
+            rent_sysvar: false,
+        });
+    let ata_address = harness.ata_address.unwrap();
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[
+            Check::success(),
+            Check::account(&ata_address)
+                .space(account_len)
+                .owner(&spl_token_interface::id())
+                .lamports(token_account_rent_exempt_balance())
+                .build(),
+        ],
+    );
+}
+
+#[test]
+fn token_2022_fails_when_hint_exceeds_system_max_account_size() {
+    let mut harness = token_2022_harness(false);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: Some(u32::MAX),
+            rent_sysvar: false,
+        });
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[Check::err(ProgramError::InvalidArgument)],
+    );
+}
+
+#[test_case(false; "base mint")]
+#[test_case(true; "transfer fee mint")]
+fn token_2022_fails_when_hint_is_tiny(transfer_fee_mint: bool) {
+    let mut harness = token_2022_harness(transfer_fee_mint);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: Some(1),
+            rent_sysvar: false,
+        });
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[Check::err(ProgramError::InvalidAccountData)],
+    );
+}
+
+#[test_case(false; "base mint")]
+#[test_case(true; "transfer fee mint")]
+fn token_2022_fails_when_hint_is_one_byte_short(transfer_fee_mint: bool) {
+    let mut harness = token_2022_harness(transfer_fee_mint);
+    let account_len = token_2022_required_account_len(transfer_fee_mint);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: Some(account_len.checked_sub(1).unwrap() as u32),
+            rent_sysvar: false,
+        });
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[Check::err(ProgramError::InvalidAccountData)],
+    );
+}
+
+#[test]
+fn token_2022_extended_fails_when_hint_omits_required_extension_space() {
+    let mut harness = token_2022_harness(true);
+    let account_len = token_2022_immutable_owner_account_len();
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: Some(account_len as u32),
+            rent_sysvar: false,
+        });
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[Check::err(ProgramError::InvalidAccountData)],
+    );
+}
+
+#[test_case(false; "base mint")]
+#[test_case(true; "transfer fee mint")]
+fn token_2022_allocates_required_size_without_hint(transfer_fee_mint: bool) {
+    let mut harness = token_2022_harness(transfer_fee_mint);
+    let account_len = token_2022_required_account_len(transfer_fee_mint);
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Always,
+            bump: None,
+            account_len: None,
+            rent_sysvar: false,
+        });
+    let ata_address = harness.ata_address.unwrap();
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[
+            Check::success(),
+            Check::account(&ata_address)
+                .space(account_len)
+                .owner(&spl_token_2022_interface::id())
+                .lamports(Rent::default().minimum_balance(account_len))
+                .build(),
+        ],
+    );
+}
+
+#[test_matrix(
+    [false, true],
+    [CreateMode::Always, CreateMode::Idempotent],
+    [0usize, 10usize]
+)]
+fn token_2022_allocates_full_hint_when_valid(
+    transfer_fee_mint: bool,
+    mode: CreateMode,
+    extra_len: usize,
+) {
+    let mut harness = token_2022_harness(transfer_fee_mint);
+    let account_len = token_2022_required_account_len(transfer_fee_mint)
+        .checked_add(extra_len)
+        .unwrap();
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode,
+            bump: None,
+            account_len: Some(account_len as u32),
+            rent_sysvar: false,
+        });
+    let ata_address = harness.ata_address.unwrap();
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[
+            Check::success(),
+            Check::account(&ata_address)
+                .space(account_len)
+                .owner(&spl_token_2022_interface::id())
+                .lamports(Rent::default().minimum_balance(account_len))
+                .build(),
+        ],
+    );
+}


### PR DESCRIPTION
This PR makes use of the `account_len` hint available in the CreateWithArgs ix. 

Saves ~2,545 CUs (~30%) on `create_with_args` for Token-2022 with extended mints.