### PR TITLE
p-ata: Short circuit on known t22 lengths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,64 +3,6 @@
 version = 4
 
 [[package]]
-name = "agave-bls12-381"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210b1ef312273aa81ccb4c52687d96e3cf07621f3619a7998be20eb9741b08e3"
-dependencies = [
- "blst",
- "blstrs",
- "bytemuck",
- "bytemuck_derive",
- "group",
- "pairing",
-]
-
-[[package]]
-name = "agave-syscalls"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84debd4abe0cbab5a6aac2ee50e3969ef0e0961f7dff7e8f96bda0be7998bca2"
-dependencies = [
- "agave-bls12-381",
- "bincode",
- "libsecp256k1",
- "num-traits",
- "solana-account",
- "solana-account-info",
- "solana-big-mod-exp",
- "solana-blake3-hasher",
- "solana-bn254",
- "solana-clock",
- "solana-cpi",
- "solana-curve25519 4.0.0",
- "solana-hash 4.2.0",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-loader-v3-interface",
- "solana-poseidon",
- "solana-program-entrypoint",
- "solana-program-runtime",
- "solana-pubkey 4.1.0",
- "solana-sbpf",
- "solana-sdk-ids",
- "solana-secp256k1-recover",
- "solana-sha256-hasher",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-svm-log-collector",
- "solana-svm-measure",
- "solana-svm-timings",
- "solana-svm-type-overrides",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-transaction-context",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,12 +358,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -1223,17 +1159,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1241,7 +1166,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1480,26 +1405,26 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.12.3",
+ "base64",
  "digest 0.9.0",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
 ]
 
 [[package]]
 name = "libsecp256k1-core"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
@@ -1508,18 +1433,18 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
  "libsecp256k1-core",
 ]
 
 [[package]]
 name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
  "libsecp256k1-core",
 ]
@@ -1571,11 +1496,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mollusk-svm"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f8c5fecb3b6543514b354b3f2757dc2f60f1b042d8f9bccff4d619102585e9"
+version = "0.13.1"
+source = "git+https://github.com/anza-xyz/mollusk?branch=4.1-beta#54d594f8fd7a514f0aaf663eab3231950a5df546"
 dependencies = [
- "agave-syscalls",
  "bincode",
  "mollusk-svm-error",
  "mollusk-svm-result",
@@ -1585,19 +1508,18 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-instructions-sysvar",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
  "solana-logger",
  "solana-message",
  "solana-precompile-error",
  "solana-program-error",
  "solana-program-runtime",
- "solana-pubkey 4.1.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-stake-interface",
@@ -1606,18 +1528,19 @@ dependencies = [
  "solana-svm-log-collector",
  "solana-svm-timings",
  "solana-svm-transaction",
+ "solana-syscalls",
  "solana-system-program",
- "solana-sysvar",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-transaction-status-client-types",
 ]
 
 [[package]]
 name = "mollusk-svm-bencher"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d412b8d3628e456a64dc0a843d42cf26825d26d3a89c25e66f833f585ae54ba2"
+version = "0.13.1"
+source = "git+https://github.com/anza-xyz/mollusk?branch=4.1-beta#54d594f8fd7a514f0aaf663eab3231950a5df546"
 dependencies = [
  "chrono",
  "mollusk-svm",
@@ -1625,46 +1548,45 @@ dependencies = [
  "serde_json",
  "solana-account",
  "solana-instruction",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca280e03a1d045faae7d8590fe1f0c892e03020fad891075f16d86123fb08ae7"
+version = "0.13.1"
+source = "git+https://github.com/anza-xyz/mollusk?branch=4.1-beta#54d594f8fd7a514f0aaf663eab3231950a5df546"
 dependencies = [
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "mollusk-svm-programs-token"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4174cfb7b85defb149b5f33bb344fbe0fa7e2a319bc2ab8f57da8cda266ed650"
+source = "git+https://github.com/anza-xyz/mollusk?branch=4.1-beta#54d594f8fd7a514f0aaf663eab3231950a5df546"
 dependencies = [
  "mollusk-svm",
  "solana-account",
  "solana-program-pack",
- "solana-pubkey 4.1.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "spl-associated-token-account-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-interface",
 ]
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc34ec3ab462bf0c984c01ca1ceb4bfb97b7e5a9d151c339de49d1e352e247e9"
+version = "0.13.1"
+source = "git+https://github.com/anza-xyz/mollusk?branch=4.1-beta#54d594f8fd7a514f0aaf663eab3231950a5df546"
 dependencies = [
  "solana-account",
  "solana-instruction",
+ "solana-message",
  "solana-program-error",
- "solana-pubkey 4.1.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-transaction-error",
+ "solana-transaction-status-client-types",
 ]
 
 [[package]]
@@ -1880,8 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "pinocchio"
-version = "0.10.2"
-source = "git+https://github.com/anza-xyz/pinocchio?rev=0ca7555836700b31dae01ef6da37ef66df1831b8#0ca7555836700b31dae01ef6da37ef66df1831b8"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -1892,9 +1815,8 @@ dependencies = [
 
 [[package]]
 name = "pinocchio"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
+version = "0.11.2"
+source = "git+https://github.com/anza-xyz/pinocchio?rev=4992a8be006c899d125bd2cd5f9eaab6ef6a2884#4992a8be006c899d125bd2cd5f9eaab6ef6a2884"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -1909,7 +1831,7 @@ version = "0.1.0"
 dependencies = [
  "codama",
  "codama-macros",
- "pinocchio 0.10.2",
+ "pinocchio 0.11.2",
  "solana-address 2.6.1",
  "solana-nullable",
  "solana-zero-copy",
@@ -1924,7 +1846,7 @@ dependencies = [
  "mollusk-svm-bencher",
  "mollusk-svm-programs-token",
  "mollusk-svm-result",
- "pinocchio 0.10.2",
+ "pinocchio 0.11.2",
  "pinocchio-associated-token-account-interface",
  "pinocchio-log",
  "pinocchio-system",
@@ -1937,8 +1859,8 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-program-pack",
- "solana-rent 4.1.0",
- "solana-system-interface 3.1.0",
+ "solana-rent 4.2.1",
+ "solana-system-interface",
  "spl-associated-token-account-interface 2.0.0",
  "spl-associated-token-account-mollusk-harness",
  "spl-token-2022-interface",
@@ -1990,8 +1912,8 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-token-2022"
-version = "0.2.0"
-source = "git+https://github.com/anza-xyz/pinocchio?rev=0ca7555836700b31dae01ef6da37ef66df1831b8#0ca7555836700b31dae01ef6da37ef66df1831b8"
+version = "0.3.1"
+source = "git+https://github.com/anza-xyz/pinocchio?rev=4992a8be006c899d125bd2cd5f9eaab6ef6a2884#4992a8be006c899d125bd2cd5f9eaab6ef6a2884"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -2087,19 +2009,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2111,22 +2020,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2151,15 +2050,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -2174,15 +2064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2297,6 +2178,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2435,9 +2325,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "solana-account"
-version = "3.4.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc0ed36decb689413b9da5d57f2be49eea5bebb3cf7897015167b0c4336e731"
+checksum = "385cad928d576683db3afef1b88d00a31a7126cc9f6f3f0c9f6b2d181437f53c"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -2447,9 +2337,23 @@ dependencies = [
  "solana-account-info",
  "solana-clock",
  "solana-instruction-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
- "solana-sysvar",
+ "solana-sysvar 4.0.0",
+]
+
+[[package]]
+name = "solana-account-decoder-client-types"
+version = "4.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d971a625a2008e802c596bf40392dcc4b5d1c2a6c9c76af11a7efed330fdff"
+dependencies = [
+ "base64",
+ "bs58",
+ "serde",
+ "serde_json",
+ "solana-account",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -2545,7 +2449,21 @@ checksum = "7116e1d942a2432ca3f514625104757ab8a56233787e95144c93950029e31176"
 dependencies = [
  "blake3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-bls12-381-syscall"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a699aa5e660203c17c18ceaef0eff78c67fd5193f4dbe90a07148e06030ab6"
+dependencies = [
+ "blst",
+ "blstrs",
+ "bytemuck",
+ "bytemuck_derive",
+ "group",
+ "pairing",
 ]
 
 [[package]]
@@ -2574,11 +2492,10 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219bfba64973ac9e64aa181f03fd56ac319e2d50d8a23d16c54bbd7fa9807a47"
+checksum = "ef26382c9ed1a359b53b1bfc06d221be7bc69b48fd672e2f5f4c18fa225d5ea7"
 dependencies = [
- "agave-syscalls",
  "bincode",
  "qualifier_attr",
  "solana-account",
@@ -2586,26 +2503,25 @@ dependencies = [
  "solana-clock",
  "solana-instruction",
  "solana-loader-v3-interface",
- "solana-loader-v4-interface",
  "solana-packet",
- "solana-program-entrypoint",
  "solana-program-runtime",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
+ "solana-syscalls",
+ "solana-system-interface",
  "solana-transaction-context",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf11109c3b6115cc510f1e31f06fdd52f504271bc24ef5f1249fbbcae5f9f3"
+checksum = "5ea35d8f69b67daddb921a9da7f78ca591b533cf5e98833cd9ae62fdc2e4652c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2615,10 +2531,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-compute-budget"
-version = "4.0.0"
+name = "solana-commitment-config"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b591fbaed6d9ab4cba6a5a82eb5df208072ced2e5b74c59e9d309ff87af0615f"
+checksum = "1517aa49dcfa9cb793ef90e7aac81346d62ca4a546bb1a754030a033e3972e1c"
+
+[[package]]
+name = "solana-compute-budget"
+version = "4.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ccfb43c9fc8f041e744c2a6413391ca906f31266bc5ac1afe78bced47a07bc"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -2634,29 +2556,15 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-stable-layout",
 ]
 
 [[package]]
 name = "solana-curve25519"
-version = "3.1.10"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d7e1177e6006823b91e0a930d94992ed74f8a6327d54ee50a9457ff72e625a"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "solana-define-syscall 3.0.0",
- "subtle",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ee66a3e25ed8d20ed6fcd1ac71735415ff1edaf33ff1ec2118826eba927bcc"
+checksum = "14b4d2a4bf0d0b0a86c22111917e86e8bd39a7b31420fb2c7d73eb83761fc7af"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -2692,7 +2600,7 @@ checksum = "f5e7b0ba210593ba8ddd39d6d234d81795d1671cebf3026baa10d5dc23ac42f0"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
@@ -2700,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
+checksum = "7ad280b1ed803853f7b453cb3ea9a57e600ca5599a63e69f7be199b486c0ec93"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2713,13 +2621,14 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-calculator"
-version = "3.1.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2a5675b2cf8d407c672dc1776492b1f382337720ddf566645ae43237a3d8c3"
+checksum = "ef67f01cc6a0c72e99a08d0d484683f995de4c80e9568728fa77d1537f9b7e09"
 dependencies = [
  "log",
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -2730,40 +2639,38 @@ checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 
 [[package]]
 name = "solana-hash"
-version = "3.1.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337c246447142f660f778cf6cb582beba8e28deb05b3b24bfb9ffd7c562e5f41"
-dependencies = [
- "solana-hash 4.2.0",
-]
-
-[[package]]
-name = "solana-hash"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8064ea1d591ec791be95245058ca40f4f5345d390c200069d0f79bbf55bfae55"
+checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "five8",
  "serde",
  "serde_derive",
- "solana-atomic-u64",
  "solana-sanitize",
+ "wincode",
 ]
 
 [[package]]
-name = "solana-instruction"
-version = "3.3.0"
+name = "solana-hash-512"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97881335fc698deb46c6571945969aae6d93a14e2fff792a368b4fac872f116"
+checksum = "7ce934b02bab639341f2fd62c3e7e3c39dcceb47f0196b7630ed1f82ecb704bd"
+
+[[package]]
+name = "solana-instruction"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "serde",
  "serde_derive",
  "solana-define-syscall 5.1.0",
  "solana-instruction-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
+ "wincode",
 ]
 
 [[package]]
@@ -2792,16 +2699,15 @@ dependencies = [
 
 [[package]]
 name = "solana-instructions-sysvar"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+checksum = "9e0732294560e88ecdb2bbc656e67383e9f88c78ec09469cef172f0d28cd1bcd"
 dependencies = [
  "bitflags",
  "solana-account-info",
  "solana-instruction",
  "solana-instruction-error",
  "solana-program-error",
- "solana-pubkey 3.0.0",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -2816,7 +2722,7 @@ checksum = "ed1c0d16d6fdeba12291a1f068cdf0d479d9bff1141bf44afd7aa9d485f65ef8"
 dependencies = [
  "sha3",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash",
 ]
 
 [[package]]
@@ -2834,31 +2740,16 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
+checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c948b33ff81fa89699911b207059e493defdba9647eaf18f23abdf3674e0fb"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -2876,17 +2767,20 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "3.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0448b1fd891c5f46491e5dc7d9986385ba3c852c340db2911dd29faa01d2b08d"
+checksum = "4ee01edb797313c1c8e1961d8ac6befc7b7cd0f90d1e9cf8f784add2b08926a3"
 dependencies = [
- "lazy_static",
+ "serde",
+ "serde_derive",
  "solana-address 2.6.1",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-instruction",
  "solana-sanitize",
  "solana-sdk-ids",
+ "solana-short-vec",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -2900,28 +2794,30 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc469152a63284ef959b80c59cda015262a021da55d3b8fe42171d89c4b64f8"
+checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
- "solana-pubkey 4.1.0",
+ "solana-hash",
+ "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-nonce-account"
-version = "3.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805fd25b29e5a1a0e6c3dd6320c9da80f275fbe4ff6e392617c303a2085c435e"
+checksum = "cda945f4ccb317791c26379ca8ec410c5938aa7a5eff211fe5fe0bb428c3a75f"
 dependencies = [
  "solana-account",
- "solana-hash 3.1.0",
+ "solana-hash",
  "solana-nonce",
  "solana-sdk-ids",
+ "wincode",
 ]
 
 [[package]]
@@ -2942,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad62e1045c2347a0c0e219a6ceb0abfe904be622920996bfcac8d116fabe3c7"
 dependencies = [
  "bitflags",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -2977,7 +2873,7 @@ dependencies = [
  "solana-account-info",
  "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -3015,17 +2911,17 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c7f89c89d5ff25f64a41c8cb00478b1d62f941f14a7dd8537c9e50bb2acc92"
+checksum = "7533a06c622b6ba0816961b207fbbc33c94021e5e193cfca3523f9c3e93d468b"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bincode",
  "cfg-if",
  "itertools 0.14.0",
  "log",
  "percentage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "solana-account",
  "solana-account-info",
@@ -3033,13 +2929,13 @@ dependencies = [
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-structure",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
  "solana-program-entrypoint",
- "solana-pubkey 4.1.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -3052,8 +2948,8 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
- "solana-sysvar",
+ "solana-system-interface",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
@@ -3070,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b06bd918d60111ee1f97de817113e2040ca0cedb740099ee8d646233f6b906c"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
  "solana-address 2.6.1",
 ]
@@ -3083,6 +2979,17 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e860d5499a705369778647e97d760f7670adfb6fc8419dd3d568deccd46d5487"
 dependencies = [
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-rent"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f02fbe2669ebe5d851dbf29a02e91ed6244b051bb64fcc57e6644aba636063"
+dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk-ids",
@@ -3091,12 +2998,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent"
-version = "4.1.0"
+name = "solana-reward-info"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1771d726d4854f1818c750e14aff40b19d84720d0b1b6d53e50e8f16cb6bd62"
+checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
 dependencies = [
- "solana-sdk-macro",
+ "serde",
+ "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -3107,9 +3016,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.14.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
+checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
 dependencies = [
  "byteorder",
  "combine",
@@ -3156,12 +3065,12 @@ dependencies = [
 
 [[package]]
 name = "solana-serialize-utils"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cc401931d178472358e6b78dc72d031dc08f752d7410f0e8bd259dd6f02fa"
+checksum = "761357b0853c9623bf12c1d2314b3d6160a85b087b84c45224fb85766d22616b"
 dependencies = [
  "solana-instruction-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sanitize",
 ]
 
@@ -3173,17 +3082,53 @@ checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
 dependencies = [
  "sha2 0.10.9",
  "solana-define-syscall 4.0.1",
- "solana-hash 4.2.0",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-sha512-hasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
+dependencies = [
+ "sha2 0.10.9",
+ "solana-define-syscall 5.1.0",
+ "solana-hash-512",
+]
+
+[[package]]
+name = "solana-short-vec"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8250a4495aad49ad20556a607da53bdcb20de78da10b65afbf918b7f1de647"
+dependencies = [
+ "serde_core",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "3.3.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132a93134f1262aa832f1849b83bec6c9945669b866da18661a427943b9e801e"
+checksum = "b0364c7577c3c82a693ce28a1febc8d1b5d1b0a175fdc2114ae6186b69effe1e"
 dependencies = [
  "five8",
+ "serde",
+ "serde-big-array",
+ "serde_derive",
  "solana-sanitize",
+ "wincode",
+]
+
+[[package]]
+name = "solana-signer"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520bd6021163ee517f4bdc7ae03ded904f97e11320001ba0b3355f45eb14f558"
+dependencies = [
+ "solana-pubkey 4.2.0",
+ "solana-signature",
+ "solana-transaction-error",
 ]
 
 [[package]]
@@ -3194,7 +3139,7 @@ checksum = "2585f70191623887329dfb5078da3a00e15e3980ea67f42c2e10b07028419f43"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
 ]
@@ -3219,14 +3164,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9f6a291ba063a37780af29e7db14bdd3dc447584d8ba5b3fc4b88e2bbc982fa"
 dependencies = [
  "solana-instruction",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-stake-interface"
-version = "2.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bc26191b533f9a6e5a14cca05174119819ced680a80febff2f5051a713f0db"
+checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
 dependencies = [
  "num-traits",
  "serde",
@@ -3235,65 +3180,65 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
+ "solana-pubkey 4.2.0",
+ "solana-system-interface",
+ "solana-sysvar 4.0.0",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-svm-callback"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4006b0da7e50cba514ced6b47bcf8f9591552458200e361fd4bdef4068cb2fed"
+checksum = "4f872a719f83dd921c69afeaca8568c9ec19cf27f017846838aeb7a1ba03723e"
 dependencies = [
  "solana-account",
  "solana-clock",
  "solana-precompile-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ea15c0d91403375e3d017cc09780cf138b629abba4ccaaa7cf66b1afea1059"
+checksum = "fe4a7ba56f1c4bd69912ad3fc5cf66152a7b36cf2ce8a36bdc77ae3a854a5a36"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb7d3ccd3a51b85807ff16b2f513069e8b55e220b280774a3e9b899bcb81987"
+checksum = "1e00e729fa6819aae3493ac99d856758cd8c38bf257b69517c924448371867da"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70c9972c1f03cb2bbc64d23dc2079419a66d89b49d6b44f79206530551ddc8c"
+checksum = "b0eb2955b0b50706622cfa5446821a3f348703961d42a322b52804efeac43447"
 
 [[package]]
 name = "solana-svm-timings"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f3d66aa88c9001a076362108f7967d6a00d121ba38428e56928935566ed5bd"
+checksum = "7162277cc214ffa7d0193a6261a4026327925572b1ffa6b8cb4902fdee16cfd9"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067861db805d135a6fbe489bf2b74d701f270df8d03afd3257f7d51a2ff3467e"
+checksum = "c909c9ee2d5a8f5fbc0d90704886ccaac2e992c59a89df9f766239f84d3fee01"
 dependencies = [
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-message",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-signature",
  "solana-transaction",
@@ -3301,33 +3246,60 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e41661ebf0edcc296b15251c08fee0ad2da3257e6ab86cea2a0a8f6fba642c6"
+checksum = "3b97cc621ec1b9f664c8902cd919418a74aeb18819aa4dedf7039d006fbd5fbc"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
-name = "solana-system-interface"
-version = "2.0.0"
+name = "solana-syscalls"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+checksum = "3cdde8e09f3224eede151671d75725c115527015bbd3c0de18d0f3cd549cc5d5"
 dependencies = [
+ "bincode",
+ "libsecp256k1",
  "num-traits",
- "serde",
- "serde_derive",
+ "solana-account",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-bls12-381-syscall",
+ "solana-bn254",
+ "solana-clock",
+ "solana-cpi",
+ "solana-curve25519",
+ "solana-hash",
+ "solana-hash-512",
  "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-keccak-hasher",
+ "solana-poseidon",
+ "solana-program-entrypoint",
+ "solana-program-runtime",
+ "solana-pubkey 4.2.0",
+ "solana-sbpf",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-sha256-hasher",
+ "solana-sha512-hasher",
+ "solana-stable-layout",
+ "solana-stake-interface",
+ "solana-svm-feature-set",
+ "solana-svm-log-collector",
+ "solana-svm-type-overrides",
+ "solana-sysvar 4.0.0",
+ "solana-sysvar-id",
+ "solana-transaction-context",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "solana-system-interface"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95a6f2e23ed861d6444ad4a6d6896c418d7d101b960787e65a8e33157cee81b"
+checksum = "55b54965bf0b76fa8e2b35376583efddd4d916618cfe595bf48c7d7b55a9e628"
 dependencies = [
  "num-traits",
  "serde",
@@ -3336,17 +3308,17 @@ dependencies = [
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-system-program"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450479004fee3396c88cc4aa2f9b2b8db9c77be42ee7c1c53e6fac9eaec5fd51"
+checksum = "452e4fbe16aca56e92f28b56a078d7e6d9fdfae9435cd6152a6fd1a18d8375f2"
 dependencies = [
  "bincode",
  "log",
- "serde",
  "solana-account",
  "solana-bincode",
  "solana-fee-calculator",
@@ -3355,12 +3327,11 @@ dependencies = [
  "solana-nonce-account",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-svm-type-overrides",
- "solana-system-interface 3.1.0",
- "solana-sysvar",
+ "solana-system-interface",
+ "solana-sysvar 4.0.0",
  "solana-transaction-context",
 ]
 
@@ -3370,25 +3341,54 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6690d3dd88f15c21edff68eb391ef8800df7a1f5cec84ee3e8d1abf05affdf74"
 dependencies = [
- "base64 0.22.1",
- "bincode",
+ "base64",
  "lazy_static",
- "serde",
- "serde_derive",
  "solana-account-info",
  "solana-clock",
  "solana-define-syscall 4.0.1",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-rent 3.1.0",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1632b69b4f72489db5949a10e8308c229dfa003f99ecaa7477b376807c7b81f4"
+dependencies = [
+ "base64",
+ "bincode",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 5.1.0",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-slot-hashes",
@@ -3408,26 +3408,31 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "3.1.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96697cff5075a028265324255efed226099f6d761ca67342b230d09f72cc48d2"
+checksum = "47d105ecce084206697230226c6b2230401c220feb4dc63e1274d58b38969292"
 dependencies = [
+ "serde",
+ "serde_derive",
  "solana-address 2.6.1",
- "solana-hash 4.2.0",
+ "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
  "solana-message",
  "solana-sanitize",
  "solana-sdk-ids",
+ "solana-short-vec",
  "solana-signature",
+ "solana-signer",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.0.0"
+version = "4.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecefe8b30e334e2891ca82da35becd9a3f4c16021d9ca782e2a82adf31084fa3"
+checksum = "2d1e190ec93b461e6f5b73b5b26c32ba8b716eff7f8355d037b8571f561c9402"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -3435,20 +3440,46 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-instructions-sysvar",
- "solana-pubkey 4.1.0",
- "solana-rent 3.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-sbpf",
  "solana-sdk-ids",
 ]
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.1.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396904805b0b385b9de115a652fe80fd01e5b98ce0513f4fcd8184ada9bb792"
+checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
 dependencies = [
+ "serde",
+ "serde_derive",
  "solana-instruction-error",
  "solana-sanitize",
+]
+
+[[package]]
+name = "solana-transaction-status-client-types"
+version = "4.1.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5315d3b1e1eceb6970760c8e647876f98441c1bdcefb8d79149f9bf4b31105db"
+dependencies = [
+ "base64",
+ "bincode",
+ "bs58",
+ "serde",
+ "serde_json",
+ "solana-account-decoder-client-types",
+ "solana-commitment-config",
+ "solana-instruction",
+ "solana-message",
+ "solana-reward-info",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -3484,7 +3515,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a800583b7a4cea3e851686af162cc6e4712eef97fa91dfa9aca2459b95c84777"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytemuck",
  "bytemuck_derive",
  "solana-nullable",
@@ -3514,11 +3545,11 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-pack",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-rent 3.1.0",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
- "solana-sysvar",
+ "solana-system-interface",
+ "solana-sysvar 3.1.1",
  "spl-associated-token-account-interface 2.0.0",
  "spl-associated-token-account-mollusk-harness",
  "spl-token-2022-interface",
@@ -3535,7 +3566,7 @@ dependencies = [
  "num-traits",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey 4.1.0",
+ "solana-pubkey 4.2.0",
  "solana-sdk-ids",
 ]
 
@@ -3561,10 +3592,10 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey 4.1.0",
- "solana-rent 4.1.0",
+ "solana-pubkey 4.2.0",
+ "solana-rent 4.2.1",
  "solana-sdk-ids",
- "solana-system-interface 3.1.0",
+ "solana-system-interface",
  "spl-associated-token-account-interface 2.0.0",
  "spl-token-2022-interface",
  "spl-token-interface",
@@ -3639,14 +3670,14 @@ dependencies = [
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd536b30c532568fad8430077875c3abc16d365e464ebfa2902bc65cb91bdc4"
+checksum = "0c1a845ec724e807643a04f1d43439ee3571dd913848112ac76aa90b850eaf7c"
 dependencies = [
  "bytemuck",
  "solana-account-info",
  "solana-address 2.6.1",
- "solana-curve25519 3.1.10",
+ "solana-curve25519",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
@@ -3979,12 +4010,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,19 @@
 resolver = "2"
 members = ["interface", "program", "mollusk_harness", "pinocchio/interface", "pinocchio/program"]
 
+[workspace.dependencies]
+# TODO: Waiting on PR #349 to merge and then be released: https://github.com/anza-xyz/pinocchio/pull/349.
+#       We need StateWithExtensions API from that PR.
+pinocchio = { version = "0.11.2", git = "https://github.com/anza-xyz/pinocchio", rev = "4992a8be006c899d125bd2cd5f9eaab6ef6a2884" }
+pinocchio-token-2022 = { version = "0.3.1", git = "https://github.com/anza-xyz/pinocchio", rev = "4992a8be006c899d125bd2cd5f9eaab6ef6a2884" }
+
+# TODO: Requires bumping to mollusk beta due to dependency requirements on token-2022-interface v3.1.
+#       It needs solana-instruction v3.4 while mollusk v0.13 requires solana-instruction <3.4.
+mollusk-svm = { git = "https://github.com/anza-xyz/mollusk", branch = "4.1-beta" }
+mollusk-svm-bencher = { git = "https://github.com/anza-xyz/mollusk", branch = "4.1-beta" }
+mollusk-svm-programs-token = { git = "https://github.com/anza-xyz/mollusk", branch = "4.1-beta" }
+mollusk-svm-result = { git = "https://github.com/anza-xyz/mollusk", branch = "4.1-beta" }
+
 [workspace.metadata.spellcheck]
 config = "scripts/spellcheck.toml"
 

--- a/mollusk_harness/Cargo.toml
+++ b/mollusk_harness/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 crate-type = ["lib"]
 
 [dependencies]
-mollusk-svm = "0.13.1"
-mollusk-svm-programs-token = "0.13.1"
+mollusk-svm = { workspace = true }
+mollusk-svm-programs-token = { workspace = true }
 pinocchio-associated-token-account-interface = { path = "../pinocchio/interface" }
-solana-account = "3.4"
+solana-account = "4.3"
 solana-instruction = "3.3"
 solana-program-error = "3.0"
 solana-program-option = "3.1"
@@ -25,5 +25,5 @@ solana-sdk-ids = "3.1"
 solana-system-interface = { version = "3.1", features = ["bincode"] }
 spl-associated-token-account-interface = { version = "2.0", path = "../interface" }
 spl-token-interface = "2.0"
-spl-token-2022-interface = "3.0"
+spl-token-2022-interface = "3.1"
 wincode = "0.5.5"

--- a/pinocchio/interface/Cargo.toml
+++ b/pinocchio/interface/Cargo.toml
@@ -16,13 +16,11 @@ codama = ["dep:codama", "dep:codama-macros"]
 [dependencies]
 codama = { version = "0.9.2", optional = true }
 codama-macros = { version = "0.9.1", optional = true }
+pinocchio = { workspace = true }
 solana-address = { version = "2.6.1", features = ["curve25519", "decode"] }
 solana-nullable = { version = "1.1.1", features = ["wincode"] }
 solana-zero-copy = { version = "1.1.1", features = ["wincode"] }
 wincode = { version = "0.5.5", default-features = false, features = ["derive"] }
-
-# TODO: Waiting on pinocchio crate publish
-pinocchio = { version = "0.10.1", git = "https://github.com/anza-xyz/pinocchio", rev = "0ca7555836700b31dae01ef6da37ef66df1831b8", default-features = false, features = ["cpi"] }
 
 [package.metadata.solana]
 program-id = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"

--- a/pinocchio/program/Cargo.toml
+++ b/pinocchio/program/Cargo.toml
@@ -17,22 +17,20 @@ program-id = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 workspace = true
 
 [dependencies]
+pinocchio = { workspace = true, features = ["cpi"] }
 pinocchio-associated-token-account-interface = { path = "../interface" }
 pinocchio-log = { version = "0.5.1", features = ["macro"] }
 pinocchio-system = "0.6.1"
 pinocchio-token = "0.6.0"
-
-# TODO: Waiting on PR #349 to merge and then be released: https://github.com/anza-xyz/pinocchio/pull/349.
-#       We need StateWithExtensions API from that PR.
-pinocchio = { version = "0.10.1", git = "https://github.com/anza-xyz/pinocchio", rev = "0ca7555836700b31dae01ef6da37ef66df1831b8", default-features = false, features = ["cpi"] }
-pinocchio-token-2022 = { version = "0.2.0", git = "https://github.com/anza-xyz/pinocchio", rev = "0ca7555836700b31dae01ef6da37ef66df1831b8" }
+pinocchio-token-2022 = { workspace = true }
+spl-token-2022-interface = "3.1.0"
 
 [dev-dependencies]
-mollusk-svm = "0.13.1"
-mollusk-svm-bencher = "0.13.1"
-mollusk-svm-programs-token = "0.13.1"
-mollusk-svm-result = "0.13.1"
-solana-account = "3.4.0"
+mollusk-svm = { workspace = true, features = ["inner-instructions"] }
+mollusk-svm-bencher = { workspace = true }
+mollusk-svm-programs-token = { workspace = true }
+mollusk-svm-result = { workspace = true, features = ["inner-instructions"] }
+solana-account = "4.3.0"
 solana-address = "2.6.1"
 solana-instruction = "3.3.0"
 solana-logger = "3.0.0"
@@ -43,7 +41,6 @@ solana-rent = "4.1.0"
 solana-system-interface = "3.1.0"
 spl-associated-token-account-interface = { path = "../../interface" }
 spl-associated-token-account-mollusk-harness = { path = "../../mollusk_harness" }
-spl-token-2022-interface = "3.0.1"
 spl-token-interface = "2.0.0"
 test-case = "3.3.1"
 

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,32 @@
+#### 2026-06-18 12:58:46.107241 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3086 | +3 |
+| create_with_args (spl-token) | 2894 | +3 |
+| create (token-2022) | 5134 | +2 |
+| create_with_args (token-2022) | 4937 | +3 |
+| create_idempotent (new, spl-token) | 4171 | -- |
+| create_with_args_idempotent (new, spl-token) | 3987 | +3 |
+| create_idempotent (new, token-2022) | 5495 | -1 |
+| create_with_args_idempotent (new, token-2022) | 5306 | +3 |
+| create_idempotent (existing, spl-token) | 531 | -17 |
+| create_with_args_idempotent (existing, spl-token) | 592 | -14 |
+| create_idempotent (existing, token-2022) | 1617 | -17 |
+| create_with_args_idempotent (existing, token-2022) | 1681 | -14 |
+| create (prefunded, spl-token) | 3086 | +3 |
+| create_with_args (prefunded, spl-token) | 2894 | +3 |
+| create (prefunded, token-2022) | 5134 | +2 |
+| create_with_args (prefunded, token-2022) | 4937 | +3 |
+| create (token-2022 known mint) | 6676 | -1,936 |
+| create_with_args (token-2022 extended mint) | 5753 | +3 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5149 | -42 |
+| recover_nested (owner=token-2022, nested=token-2022) | 7013 | -42 |
+| recover_nested (owner=spl-token, nested=token-2022) | 9569 | -42 |
+| recover_nested (owner=token-2022, nested=spl-token) | 5519 | -42 |
+
 #### 2026-05-21 08:39:23.395979 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
@@ -20,6 +49,7 @@ Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agav
 | create_with_args (prefunded, spl-token) | 2891 | -119 |
 | create (prefunded, token-2022) | 5132 | -118 |
 | create_with_args (prefunded, token-2022) | 4934 | -119 |
+| create (token-2022 known mint) | 8612 | - new - |
 | create_with_args (token-2022 extended mint) | 5750 | -119 |
 | recover_nested (owner=spl-token, nested=spl-token) | 5191 | -- |
 | recover_nested (owner=token-2022, nested=token-2022) | 7055 | -- |

--- a/pinocchio/program/benches/compute_units.rs
+++ b/pinocchio/program/benches/compute_units.rs
@@ -560,6 +560,12 @@ fn main() {
         system_account.clone(),
         t22_account.clone(),
     ];
+    let ix2_extended = create_associated_token_account(
+        &payer,
+        &wallet2_extended,
+        &t22_extended_mint,
+        &spl_token_2022_interface::id(),
+    );
     let ix2_extended_create_with_args = create_associated_token_account_with_args(
         &payer,
         &wallet2_extended,
@@ -662,6 +668,11 @@ fn main() {
             "create_with_args (prefunded, token-2022)",
             &ix5b_create_with_args,
             &accs5b_create_with_args,
+        ))
+        .bench((
+            "create (token-2022 known mint)",
+            &ix2_extended,
+            &accs2_extended,
         ))
         .bench((
             "create_with_args (token-2022 extended mint)",

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -8,7 +8,7 @@ use {
     },
     pinocchio_system::instructions::CreateAccountAllowPrefund,
     pinocchio_token::instructions::InitializeAccount3,
-    pinocchio_token_2022::state::{AccountState, StateWithExtensions, TokenAccount},
+    pinocchio_token_2022::state::{Account, AccountState, StateWithExtensions},
 };
 
 #[inline(always)]
@@ -70,16 +70,15 @@ pub(crate) fn process_create_associated_token_account(
     {
         let ata_data = associated_token_account.try_borrow()?;
         // Preexisting ATA must be parsable as a token account
-        if let Ok(token_account_ext) = StateWithExtensions::<TokenAccount>::from_bytes(&ata_data) {
-            let token_account = token_account_ext.base();
+        if let Ok(token_account) = StateWithExtensions::<Account>::from_bytes(&ata_data) {
             // Preexisting ATA cannot be in the uninitialized state
-            if let Ok(account_state) = token_account.state() {
+            if let Ok(account_state) = token_account.base.state() {
                 if account_state != AccountState::Uninitialized {
                     // Now that ATA is confirmed, it must match the wallet and mint supplied
-                    if token_account.owner() != wallet.address() {
+                    if token_account.base.owner() != wallet.address() {
                         return Err(AssociatedTokenAccountError::InvalidOwner.into());
                     }
-                    if token_account.mint() != mint.address() {
+                    if token_account.base.mint() != mint.address() {
                         return Err(ProgramError::InvalidAccountData);
                     }
                     // `derive_address_with_bump_hint()` rejects higher off-curve bumps but
@@ -102,7 +101,7 @@ pub(crate) fn process_create_associated_token_account(
 
     let is_spl_token = *token_program.address() == pinocchio_token::ID;
     let account_len = if is_spl_token {
-        TokenAccount::BASE_LEN as u64
+        Account::BASE_LEN as u64
     } else if *token_program.address() == pinocchio_token_2022::ID {
         // Undersized accounts fail during initialization and excessive sizes fail
         // through rent/system account-size limits.

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -8,7 +8,7 @@ use {
     pinocchio_log::log,
     pinocchio_token_2022::{
         instructions::{CloseAccount, TransferChecked},
-        state::{Mint, StateWithExtensions, TokenAccount},
+        state::{Account, Mint, StateWithExtensions},
     },
 };
 
@@ -122,10 +122,10 @@ pub(crate) fn process_recover_nested(
     }
 
     let owner_account_data = owner_ata.try_borrow()?;
-    let owner_account = StateWithExtensions::<TokenAccount>::from_bytes(&owner_account_data)?;
+    let owner_account = StateWithExtensions::<Account>::from_bytes(&owner_account_data)?;
 
     // The wallet must actually control this ATA
-    if owner_account.base().owner() != wallet.address() {
+    if owner_account.base.owner() != wallet.address() {
         log!("Owner associated token account not owned by provided wallet");
         return Err(AssociatedTokenAccountError::InvalidOwner.into());
     }
@@ -138,10 +138,10 @@ pub(crate) fn process_recover_nested(
     }
 
     let nested_account_data = nested_ata.try_borrow()?;
-    let nested_account = StateWithExtensions::<TokenAccount>::from_bytes(&nested_account_data)?;
+    let nested_account = StateWithExtensions::<Account>::from_bytes(&nested_account_data)?;
 
     // Confirming this is genuinely a nested ATA, not an arbitrary token account
-    if nested_account.base().owner() != owner_ata.address() {
+    if nested_account.base.owner() != owner_ata.address() {
         log!("Nested associated token account not owned by provided associated token account");
         return Err(AssociatedTokenAccountError::InvalidOwner.into());
     }
@@ -154,8 +154,8 @@ pub(crate) fn process_recover_nested(
 
     let nested_mint_data = nested_token_mint.try_borrow()?;
     let nested_mint = StateWithExtensions::<Mint>::from_bytes(&nested_mint_data)?;
-    let amount = nested_account.base().amount();
-    let decimals = nested_mint.base().decimals();
+    let amount = nested_account.base.amount();
+    let decimals = nested_mint.base.decimals();
     drop(nested_account_data);
 
     let bump_ref = &[bump_seed];

--- a/pinocchio/program/src/size.rs
+++ b/pinocchio/program/src/size.rs
@@ -1,14 +1,12 @@
 use {
-    pinocchio::{
-        AccountView,
-        cpi::{self, get_return_data},
-        error::ProgramError,
-        instruction::{InstructionAccount, InstructionView},
-    },
+    pinocchio::{AccountView, cpi::get_return_data, error::ProgramError},
     pinocchio_log::log,
     pinocchio_token_2022::{
         instructions::GetAccountDataSize,
-        state::{ExtensionType, Mint, TokenAccount},
+        state::{Account, ExtensionType, Mint},
+    },
+    spl_token_2022_interface::extension::{
+        ExtensionType as SplExtensionType, account_len::try_calculate_account_len_from_mint_data,
     },
 };
 
@@ -21,7 +19,7 @@ const ACCOUNT_TYPE_SIZE: usize = 1;
 /// Reference: https://github.com/anza-xyz/pinocchio/blob/0ca7555836700b31dae01ef6da37ef66df1831b8/programs/token-2022/src/state/extension/mod.rs#L31
 const TLV_HEADER_LEN: usize = 4;
 const TOKEN_2022_BASE_ACCOUNT_DATA_SIZE: u64 =
-    TokenAccount::BASE_LEN as u64 + ACCOUNT_TYPE_SIZE as u64 + TLV_HEADER_LEN as u64;
+    Account::BASE_LEN as u64 + ACCOUNT_TYPE_SIZE as u64 + TLV_HEADER_LEN as u64;
 
 /// Get the required Token-2022 account data size when no account length hint was supplied.
 /// Short-circuits when size is known and falls back to `GetAccountDataSize` CPI for
@@ -39,6 +37,14 @@ pub(crate) fn get_token_2022_account_data_size(
         return Ok(TOKEN_2022_BASE_ACCOUNT_DATA_SIZE);
     }
 
+    // Avoid the CPI when the mint data can be used to derive the account size locally.
+    // If there is failure, fallback to a normal CPI to the token program.
+    if let Ok(len) = mint.try_borrow().and_then(|mint_data| {
+        try_calculate_account_len_from_mint_data(&mint_data, &[SplExtensionType::ImmutableOwner])
+    }) {
+        return Ok(len as u64);
+    }
+
     get_account_data_size_cpi(mint, token_program)
 }
 
@@ -46,23 +52,14 @@ fn get_account_data_size_cpi(
     mint: &AccountView,
     token_program: &AccountView,
 ) -> Result<u64, ProgramError> {
-    let mint_address = mint.address();
     let token_program_address = token_program.address();
 
-    // TODO: pinocchio's `GetAccountDataSize` builder does not yet support `ImmutableOwner`
-    let mut get_account_data_size_ix = [0; 3];
-    get_account_data_size_ix[0] = GetAccountDataSize::DISCRIMINATOR;
-    get_account_data_size_ix[1..]
-        .copy_from_slice(&(ExtensionType::ImmutableOwner as u16).to_le_bytes());
-
-    cpi::invoke(
-        &InstructionView {
-            program_id: token_program_address,
-            accounts: &[InstructionAccount::readonly(mint_address)],
-            data: &get_account_data_size_ix,
-        },
-        &[mint],
-    )?;
+    GetAccountDataSize {
+        mint,
+        extensions: &[ExtensionType::ImmutableOwner],
+        token_program: token_program_address,
+    }
+    .invoke()?;
 
     get_return_data()
         .ok_or_else(|| {

--- a/pinocchio/program/tests/t22_account_len.rs
+++ b/pinocchio/program/tests/t22_account_len.rs
@@ -1,0 +1,173 @@
+use {
+    core::mem::size_of,
+    mollusk_svm_result::Check,
+    solana_address::Address,
+    solana_program_option::COption,
+    solana_program_pack::Pack,
+    solana_rent::Rent,
+    spl_associated_token_account_mollusk_harness::{
+        AtaProgram, AtaTestHarness, CreateAtaInstructionType,
+        token_2022_immutable_owner_account_len,
+    },
+    spl_token_2022_interface::{
+        extension::{
+            BaseStateWithExtensionsMut, ExtensionType, StateWithExtensionsMut,
+            account_len::try_calculate_account_len_from_mint_data,
+            mint_close_authority::MintCloseAuthority, non_transferable::NonTransferable,
+            pausable::PausableConfig, transfer_fee::TransferFeeConfig, transfer_hook::TransferHook,
+        },
+        state::{Account as Token2022Account, Mint},
+    },
+    test_case::test_case,
+};
+
+const CREATE_FAST_PATH_INNER_IX_COUNT: usize = 2; // `CreateAccountAllowPrefund` and Batch
+const FAILED_SIZE_CPI_FALLBACK_INNER_IX_COUNT: usize = 1; // `GetAccountDataSize`
+
+fn token_2022_raw_mint_harness(mint_extensions: &[ExtensionType]) -> (AtaTestHarness, usize) {
+    let mint_space = ExtensionType::try_calculate_account_len::<Mint>(mint_extensions).unwrap();
+    let mut mint_data = vec![0; mint_space];
+    let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
+
+    for extension_type in mint_extensions {
+        match extension_type {
+            ExtensionType::TransferFeeConfig => {
+                state.init_extension::<TransferFeeConfig>(true).unwrap();
+            }
+            ExtensionType::NonTransferable => {
+                state.init_extension::<NonTransferable>(true).unwrap();
+            }
+            ExtensionType::TransferHook => {
+                state.init_extension::<TransferHook>(true).unwrap();
+            }
+            ExtensionType::Pausable => {
+                state.init_extension::<PausableConfig>(true).unwrap();
+            }
+            ExtensionType::MintCloseAuthority => {
+                state.init_extension::<MintCloseAuthority>(true).unwrap();
+            }
+            _ => panic!("unsupported raw mint extension for this test"),
+        }
+    }
+
+    state.base = Mint {
+        mint_authority: COption::Some(Address::new_unique()),
+        supply: 1_000_000,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    };
+    state.pack_base();
+    state.init_account_type().unwrap();
+
+    let account_len =
+        try_calculate_account_len_from_mint_data(&mint_data, &[ExtensionType::ImmutableOwner])
+            .unwrap();
+
+    (
+        AtaTestHarness::new_with_ata_program(
+            &spl_token_2022_interface::id(),
+            AtaProgram::Pinocchio,
+        )
+        .with_wallet(1_000_000)
+        .with_raw_mint(
+            spl_token_2022_interface::id(),
+            Rent::default().minimum_balance(mint_space),
+            mint_data,
+        ),
+        account_len,
+    )
+}
+
+fn assert_create_uses_fast_path(
+    mut harness: AtaTestHarness,
+    instruction_type: CreateAtaInstructionType,
+    account_len: usize,
+) {
+    let instruction = harness.build_create_ata_instruction(instruction_type);
+    let ata_address = harness.ata_address.unwrap();
+
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[
+            Check::success(),
+            Check::inner_instruction_count(CREATE_FAST_PATH_INNER_IX_COUNT),
+            Check::account(&ata_address)
+                .space(account_len)
+                .owner(&spl_token_2022_interface::id())
+                .lamports(Rent::default().minimum_balance(account_len))
+                .build(),
+        ],
+    );
+}
+
+#[test_case(CreateAtaInstructionType::Create)]
+#[test_case(CreateAtaInstructionType::CreateIdempotent)]
+fn base_mint_uses_fast_path(instruction_type: CreateAtaInstructionType) {
+    let harness = AtaTestHarness::new_with_ata_program(
+        &spl_token_2022_interface::id(),
+        AtaProgram::Pinocchio,
+    )
+    .with_wallet_and_mint(1_000_000, 6);
+    assert_create_uses_fast_path(
+        harness,
+        instruction_type,
+        token_2022_immutable_owner_account_len(),
+    );
+}
+
+#[test_case(&[ExtensionType::MintCloseAuthority]; "without account-side extension, stays at base size")]
+#[test_case(&[ExtensionType::TransferFeeConfig]; "with account-side extension, grows beyond base size")]
+#[test_case(&[
+    ExtensionType::TransferFeeConfig,
+    ExtensionType::NonTransferable,
+    ExtensionType::TransferHook,
+    ExtensionType::Pausable,
+]; "multiple extensions")]
+fn mint_with_extensions_uses_fast_path(mint_extensions: &[ExtensionType]) {
+    let (harness, account_len) = token_2022_raw_mint_harness(mint_extensions);
+    assert_create_uses_fast_path(harness, CreateAtaInstructionType::Create, account_len);
+}
+
+#[test]
+fn invalid_mint_extension_data_falls_back_to_cpi() {
+    let mint_space =
+        ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MintCloseAuthority])
+            .unwrap();
+    let mut mint_data = vec![0u8; mint_space];
+    let mut state = StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
+    state.init_extension::<MintCloseAuthority>(true).unwrap();
+    state.base = Mint {
+        mint_authority: COption::Some(Address::new_unique()),
+        supply: 1_000_000,
+        decimals: 6,
+        is_initialized: true,
+        freeze_authority: COption::None,
+    };
+    state.pack_base();
+    state.init_account_type().unwrap();
+
+    // Corrupt the first extension's type discriminant so local parsing fails
+    let extension_type_offset = Token2022Account::LEN.checked_add(size_of::<u8>()).unwrap();
+    mint_data[extension_type_offset..extension_type_offset + size_of::<u16>()]
+        .copy_from_slice(&u16::MAX.to_le_bytes());
+
+    let mut harness = AtaTestHarness::new_with_ata_program(
+        &spl_token_2022_interface::id(),
+        AtaProgram::Pinocchio,
+    )
+    .with_wallet(1_000_000)
+    .with_raw_mint(
+        spl_token_2022_interface::id(),
+        Rent::default().minimum_balance(mint_space),
+        mint_data,
+    );
+    let instruction = harness.build_create_ata_instruction(CreateAtaInstructionType::Create);
+    let result = harness.ctx.process_instruction(&instruction);
+
+    assert!(result.raw_result.is_err());
+    assert_eq!(
+        result.inner_instructions.len(),
+        FAILED_SIZE_CPI_FALLBACK_INNER_IX_COUNT
+    );
+}

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -29,7 +29,7 @@ spl-token-interface = "2.0.0"
 spl-token-2022-interface = "3.0.1"
 
 [dev-dependencies]
-mollusk-svm = "0.13.1"
+mollusk-svm = { workspace = true }
 spl-associated-token-account-mollusk-harness = { version = "1.0.0", path = "../mollusk_harness" }
 solana-program-pack = "3.1"
 test-case = "3.3.1"


### PR DESCRIPTION
The final optimization from https://github.com/solana-program/associated-token-account/pull/102

Instead of always doing the `GetAccountDataSize` CPI into Token-2022 for account length, we can hardcode a set of known extension lengths. Multi-extension mints, variable length or unknown ones will still fallback to the CPI.

Saves ~1,936 CUs (~30%) on this new code path.
