### PR TITLE
interface: move `error` module from `program` to `interface`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,8 +3507,6 @@ version = "8.0.0"
 dependencies = [
  "borsh",
  "mollusk-svm",
- "num-derive",
- "num-traits",
  "solana-account-info",
  "solana-cpi",
  "solana-instruction",
@@ -3526,7 +3524,6 @@ dependencies = [
  "spl-token-2022-interface",
  "spl-token-interface",
  "test-case",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3534,9 +3531,13 @@ name = "spl-associated-token-account-interface"
 version = "2.0.0"
 dependencies = [
  "borsh",
+ "num-derive",
+ "num-traits",
  "solana-instruction",
+ "solana-program-error",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,7 +3537,6 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -12,8 +12,12 @@ borsh = ["dep:borsh"]
 
 [dependencies]
 borsh = { version = "1", optional = true, features = ["unstable__schema"] }
+num-derive = "0.4"
+num-traits = "0.2"
 solana-instruction = { version = "3.3.0", features = ["std"] }
+solana-program-error = "3.0"
 solana-pubkey = { version = "4.1.0", features = ["curve25519"] }
+thiserror = "2.0"
 
 [dev-dependencies]
 solana-sdk-ids = "3.1.0"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -14,10 +14,9 @@ borsh = ["dep:borsh"]
 borsh = { version = "1", optional = true, features = ["unstable__schema"] }
 num-derive = "0.4"
 num-traits = "0.2"
-solana-instruction = { version = "3.3.0", features = ["std"] }
+solana-instruction = "3.3.0"
 solana-program-error = "3.0"
-solana-pubkey = { version = "4.1.0", features = ["curve25519"] }
-thiserror = "2.0"
+solana-pubkey = { version = "4.1.0", default-features = false, features = ["curve25519"] }
 
 [dev-dependencies]
 solana-sdk-ids = "3.1.0"

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,0 +1,17 @@
+//! Error types
+
+use {num_derive::FromPrimitive, solana_program_error::ProgramError, thiserror::Error};
+
+/// Errors that may be returned by the program.
+#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+pub enum AssociatedTokenAccountError {
+    // 0
+    /// Associated token account owner does not match address derivation
+    #[error("Associated token account owner does not match address derivation")]
+    InvalidOwner,
+}
+impl From<AssociatedTokenAccountError> for ProgramError {
+    fn from(e: AssociatedTokenAccountError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,15 +1,31 @@
 //! Error types
 
-use {num_derive::FromPrimitive, solana_program_error::ProgramError, thiserror::Error};
+use {
+    core::{error::Error, fmt},
+    num_derive::FromPrimitive,
+    solana_program_error::ProgramError,
+};
 
 /// Errors that may be returned by the program.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
+#[derive(Clone, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum AssociatedTokenAccountError {
     // 0
     /// Associated token account owner does not match address derivation
-    #[error("Associated token account owner does not match address derivation")]
     InvalidOwner,
 }
+
+impl Error for AssociatedTokenAccountError {}
+
+impl fmt::Display for AssociatedTokenAccountError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            AssociatedTokenAccountError::InvalidOwner {} => {
+                f.write_str("Associated token account owner does not match address derivation")
+            }
+        }
+    }
+}
+
 impl From<AssociatedTokenAccountError> for ProgramError {
     fn from(e: AssociatedTokenAccountError) -> Self {
         ProgramError::Custom(e as u32)

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -19,7 +19,7 @@ impl Error for AssociatedTokenAccountError {}
 impl fmt::Display for AssociatedTokenAccountError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AssociatedTokenAccountError::InvalidOwner {} => {
+            AssociatedTokenAccountError::InvalidOwner => {
                 f.write_str("Associated token account owner does not match address derivation")
             }
         }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 
 pub mod address;
+pub mod error;
 pub mod instruction;
 
 /// Module defining the program id

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,8 +13,6 @@ test-sbf = []
 
 [dependencies]
 borsh = "1.6.1"
-num-derive = "0.4"
-num-traits = "0.2"
 solana-account-info = "3.1"
 solana-cpi = "3.1"
 solana-instruction = "3.3"
@@ -29,7 +27,6 @@ solana-sysvar = "3.1"
 spl-associated-token-account-interface = { version = "2.0.0", path = "../interface", features = ["borsh"] }
 spl-token-interface = "2.0.0"
 spl-token-2022-interface = "3.0.1"
-thiserror = "2.0"
 
 [dev-dependencies]
 mollusk-svm = "0.13.1"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -19,7 +19,7 @@ solana-instruction = "3.3"
 solana-msg = "3.1"
 solana-program-entrypoint = "3.1"
 solana-program-error = "3.0"
-solana-pubkey = "4.1"
+solana-pubkey = { version = "4.1", default-features = false }
 solana-rent = "3.1"
 solana-sdk-ids = "3.1"
 solana-system-interface = { version = "3.1", features = ["bincode"] }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -1,17 +1,8 @@
 //! Error types
 
-use {num_derive::FromPrimitive, solana_program_error::ProgramError, thiserror::Error};
-
-/// Errors that may be returned by the program.
-#[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]
-pub enum AssociatedTokenAccountError {
-    // 0
-    /// Associated token account owner does not match address derivation
-    #[error("Associated token account owner does not match address derivation")]
-    InvalidOwner,
-}
-impl From<AssociatedTokenAccountError> for ProgramError {
-    fn from(e: AssociatedTokenAccountError) -> Self {
-        ProgramError::Custom(e as u32)
-    }
-}
+#![deprecated(
+    since = "8.1.0",
+    note = "Use `spl_associated_token_account_interface::error` instead and remove \
+            `spl_associated_token_account` as a dependency"
+)]
+pub use spl_associated_token_account_interface::error::*;

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,10 +1,7 @@
 //! Program state processor
 
 use {
-    crate::{
-        error::AssociatedTokenAccountError,
-        tools::account::{create_pda_account, get_account_len},
-    },
+    crate::tools::account::{create_pda_account, get_account_len},
     borsh::BorshDeserialize,
     solana_account_info::{AccountInfo, next_account_info},
     solana_cpi::{invoke, invoke_signed},
@@ -16,7 +13,7 @@ use {
     solana_sysvar::Sysvar,
     spl_associated_token_account_interface::{
         address::get_associated_token_address_and_bump_seed_internal,
-        instruction::AssociatedTokenAccountInstruction,
+        error::AssociatedTokenAccountError, instruction::AssociatedTokenAccountInstruction,
     },
     spl_token_2022_interface::{
         extension::{ExtensionType, StateWithExtensions},


### PR DESCRIPTION
### Problem
For `p-ata` the `error` module resides in the `interface`, but for `spl-ata` it is in the `program`.

### Solution
Move the `error` module from the `program` to the `interface`.