### PR TITLE
p-ata: `RecoverNested` multisig support

### DIFF
--- a/mollusk_harness/src/lib.rs
+++ b/mollusk_harness/src/lib.rs
@@ -472,12 +472,13 @@ impl AtaTestHarness {
         nested_mint: Pubkey,
     ) -> solana_instruction::Instruction {
         let wallet = self.wallet.as_ref().expect("Wallet must be set");
-
-        spl_associated_token_account_interface::instruction::recover_nested(
+        build_recover_nested_instruction(
             wallet,
             &owner_mint,
             &nested_mint,
             &self.token_program_id,
+            &self.token_program_id,
+            &[],
         )
     }
 
@@ -698,6 +699,53 @@ pub fn build_create_ata_instruction(
         program_id: ata_program_id,
         accounts,
         data: encode_create_ata_instruction_data(&instruction_type),
+    }
+}
+
+pub fn build_recover_nested_instruction(
+    wallet: &Pubkey,
+    owner_mint: &Pubkey,
+    nested_mint: &Pubkey,
+    owner_token_program_id: &Pubkey,
+    nested_token_program_id: &Pubkey,
+    multisig_signers: &[&Pubkey],
+) -> Instruction {
+    let owner_ata =
+        get_associated_token_address_with_program_id(wallet, owner_mint, owner_token_program_id);
+    let destination_ata =
+        get_associated_token_address_with_program_id(wallet, nested_mint, nested_token_program_id);
+    let nested_ata = get_associated_token_address_with_program_id(
+        &owner_ata,
+        nested_mint,
+        nested_token_program_id,
+    );
+
+    let mut accounts = vec![
+        AccountMeta::new(nested_ata, false),
+        AccountMeta::new_readonly(*nested_mint, false),
+        AccountMeta::new(destination_ata, false),
+        AccountMeta::new_readonly(owner_ata, false),
+        AccountMeta::new_readonly(*owner_mint, false),
+        AccountMeta::new(*wallet, multisig_signers.is_empty()),
+        AccountMeta::new_readonly(*owner_token_program_id, false),
+    ];
+
+    // The nested token program account is normally optional, but with
+    // multisig accounts, to have a stable order, the nested account is added
+    if owner_token_program_id != nested_token_program_id || !multisig_signers.is_empty() {
+        accounts.push(AccountMeta::new_readonly(*nested_token_program_id, false));
+    }
+
+    accounts.extend(
+        multisig_signers
+            .iter()
+            .map(|s| AccountMeta::new_readonly(**s, true)),
+    );
+
+    Instruction {
+        program_id: spl_associated_token_account_interface::program::id(),
+        accounts,
+        data: wincode::serialize(&AssociatedTokenAccountInstruction::RecoverNested).unwrap(),
     }
 }
 

--- a/pinocchio/interface/idl.json
+++ b/pinocchio/interface/idl.json
@@ -237,9 +237,9 @@
             "kind": "instructionAccountNode",
             "name": "wallet",
             "isWritable": true,
-            "isSigner": true,
+            "isSigner": "either",
             "docs": [
-              "Wallet address for the owner associated token account"
+              "Wallet address for the owner associated token account. If multisig, not a signer."
             ]
           },
           {
@@ -258,7 +258,7 @@
             "isSigner": false,
             "isOptional": true,
             "docs": [
-              "Optional token program for the nested mint, if different from the owner mint's token program"
+              "Optional token program for the nested mint, if different from the owner mint's token program. Required when the wallet is a multisig."
             ]
           }
         ],

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -91,18 +91,31 @@ pub enum AssociatedTokenAccountInstruction {
     /// created unintentionally, so this instruction should only be used to
     /// recover from errors.
     ///
+    /// Accounts expected by this instruction:
+    ///
+    ///   * Single owner
     ///   0. `[writeable]` Nested associated token account, must be owned by `3`
     ///   1. `[]` Token mint for the nested associated token account
     ///   2. `[writeable]` Wallet's associated token account
     ///   3. `[]` Owner associated token account address, must be owned by `5`
     ///   4. `[]` Token mint for the owner associated token account
     ///   5. `[writeable, signer]` Wallet address for the owner associated token
-    ///      account. If multisig, not a signer.
+    ///      account
     ///   6. `[]` Token program for the owner mint
     ///   7. `[]` Optional token program for the nested mint, if different from
-    ///      the owner mint's token program. Required when the wallet is a
-    ///      multisig.
-    ///   8. `..8+M` `[signer]` M multisig signer accounts that authorize the
+    ///      the owner mint's token program
+    ///
+    ///   * Multisignature owner
+    ///   0. `[writeable]` Nested associated token account, must be owned by `3`
+    ///   1. `[]` Token mint for the nested associated token account
+    ///   2. `[writeable]` Wallet's associated token account
+    ///   3. `[]` Owner associated token account address, must be owned by `5`
+    ///   4. `[]` Token mint for the owner associated token account
+    ///   5. `[writeable]` Multisignature wallet address for the owner associated
+    ///      token account
+    ///   6. `[]` Token program for the owner mint
+    ///   7. `[]` Token program for the nested mint
+    ///   8. `..+M` `[signer]` M multisig signer accounts that authorize the
     ///      wallet
     #[cfg_attr(
         feature = "codama",

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -97,10 +97,13 @@ pub enum AssociatedTokenAccountInstruction {
     ///   3. `[]` Owner associated token account address, must be owned by `5`
     ///   4. `[]` Token mint for the owner associated token account
     ///   5. `[writeable, signer]` Wallet address for the owner associated token
-    ///      account
+    ///      account. If multisig, not a signer.
     ///   6. `[]` Token program for the owner mint
     ///   7. `[]` Optional token program for the nested mint, if different from
-    ///      the owner mint's token program
+    ///      the owner mint's token program. Required when the wallet is a
+    ///      multisig.
+    ///   8. `..8+M` `[signer]` M multisig signer accounts that authorize the
+    ///      wallet
     #[cfg_attr(
         feature = "codama",
         codama(optional_account_strategy = omitted),
@@ -129,9 +132,9 @@ pub enum AssociatedTokenAccountInstruction {
         )),
         codama(account(
             name = "wallet",
-            signer,
+            signer = "either",
             writable,
-            docs = "Wallet address for the owner associated token account"
+            docs = "Wallet address for the owner associated token account. If multisig, not a signer."
         )),
         codama(account(
             name = "owner_token_program",
@@ -141,7 +144,7 @@ pub enum AssociatedTokenAccountInstruction {
             name = "nested_token_program",
             optional,
             docs = "Optional token program for the nested mint, if different from the owner \
-                    mint's token program"
+                    mint's token program. Required when the wallet is a multisig."
         ))
     )]
     RecoverNested,

--- a/pinocchio/program/Cargo.toml
+++ b/pinocchio/program/Cargo.toml
@@ -23,7 +23,6 @@ pinocchio-log = { version = "0.5.1", features = ["macro"] }
 pinocchio-system = "0.6.1"
 pinocchio-token = "0.6.0"
 pinocchio-token-2022 = { workspace = true }
-solana-program-pack = "3.1.0"
 spl-token-2022-interface = "3.1.0"
 
 [dev-dependencies]
@@ -37,6 +36,7 @@ solana-instruction = "3.3.0"
 solana-logger = "3.0.0"
 solana-program-error = "3.0.0"
 solana-program-option = "3.1.0"
+solana-program-pack = "3.1.0"
 solana-rent = "4.1.0"
 solana-system-interface = "3.1.0"
 spl-associated-token-account-interface = { path = "../../interface" }

--- a/pinocchio/program/Cargo.toml
+++ b/pinocchio/program/Cargo.toml
@@ -23,6 +23,7 @@ pinocchio-log = { version = "0.5.1", features = ["macro"] }
 pinocchio-system = "0.6.1"
 pinocchio-token = "0.6.0"
 pinocchio-token-2022 = { workspace = true }
+solana-program-pack = "3.1.0"
 spl-token-2022-interface = "3.1.0"
 
 [dev-dependencies]
@@ -36,7 +37,6 @@ solana-instruction = "3.3.0"
 solana-logger = "3.0.0"
 solana-program-error = "3.0.0"
 solana-program-option = "3.1.0"
-solana-program-pack = "3.1.0"
 solana-rent = "4.1.0"
 solana-system-interface = "3.1.0"
 spl-associated-token-account-interface = { path = "../../interface" }

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,32 @@
+#### 2026-06-26 14:26:58.508025 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3085 | -- |
+| create_with_args (spl-token) | 2831 | -- |
+| create (token-2022) | 5132 | -- |
+| create_with_args (token-2022) | 4925 | -- |
+| create_idempotent (new, spl-token) | 4171 | -- |
+| create_with_args_idempotent (new, spl-token) | 3925 | -- |
+| create_idempotent (new, token-2022) | 5496 | -- |
+| create_with_args_idempotent (new, token-2022) | 5295 | -- |
+| create_idempotent (existing, spl-token) | 530 | -- |
+| create_with_args_idempotent (existing, spl-token) | 387 | -- |
+| create_idempotent (existing, token-2022) | 1616 | -- |
+| create_with_args_idempotent (existing, token-2022) | 387 | -- |
+| create (prefunded, spl-token) | 3085 | -- |
+| create_with_args (prefunded, spl-token) | 2831 | -- |
+| create (prefunded, token-2022) | 5132 | -- |
+| create_with_args (prefunded, token-2022) | 4925 | -- |
+| create (token-2022 known mint) | 6674 | -- |
+| create_with_args (token-2022 extended mint) | 5741 | -- |
+| recover_nested (owner=spl-token, nested=spl-token) | 5152 | +4 |
+| recover_nested (owner=token-2022, nested=token-2022) | 7016 | +4 |
+| recover_nested (owner=spl-token, nested=token-2022) | 9572 | +4 |
+| recover_nested (owner=token-2022, nested=spl-token) | 5522 | +4 |
+
 #### 2026-06-25 16:04:39.216202 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -10,6 +10,8 @@ use {
         instructions::{CloseAccount, TransferChecked},
         state::{Account, Mint, StateWithExtensions},
     },
+    solana_program_pack::Pack,
+    spl_token_2022_interface::{instruction::MAX_SIGNERS, state::Multisig},
 };
 
 /// Recovers tokens stuck in a "nested" ATA (one that was created by mistakenly using an ATA address
@@ -99,8 +101,12 @@ pub(crate) fn process_recover_nested(
         return Err(ProgramError::InvalidSeeds);
     }
 
-    // Only the wallet holder can trigger recovery
-    if !wallet.is_signer() {
+    // Multisig wallets are authorized by their configured signer accounts.
+    // Other wallet accounts must sign directly.
+    if wallet.owned_by(owner_token_program.address()) && wallet.data_len() == Multisig::LEN {
+        let wallet_signers = remaining.get(1..).unwrap_or_default();
+        validate_multisig_wallet(wallet, wallet_signers)?;
+    } else if !wallet.is_signer() {
         log!("Wallet of the owner associated token account must sign");
         return Err(ProgramError::MissingRequiredSignature);
     }
@@ -186,4 +192,42 @@ pub(crate) fn process_recover_nested(
         token_program: nested_token_program.address(),
     }
     .invoke_signed(&[Signer::from(&seeds)])
+}
+
+#[inline(always)]
+fn validate_multisig_wallet(
+    wallet: &AccountView,
+    signer_accounts: &[AccountView],
+) -> ProgramResult {
+    let wallet_data = wallet.try_borrow()?;
+    let multisig = Multisig::unpack(&wallet_data)?;
+
+    let mut num_signers: usize = 0;
+    let mut matched = [false; MAX_SIGNERS];
+    let signers = &multisig.signers[..usize::from(multisig.n)];
+
+    // Count distinct configured signers that signed
+    for signer_account in signer_accounts {
+        for (position, signer) in signers.iter().enumerate() {
+            // Match on address, skipping signers already credited
+            if signer == signer_account.address() && !matched[position] {
+                // A matching account must have signed the transaction
+                if !signer_account.is_signer() {
+                    return Err(ProgramError::MissingRequiredSignature);
+                }
+                matched[position] = true;
+                num_signers = num_signers
+                    .checked_add(1)
+                    .ok_or(ProgramError::InvalidInstructionData)?;
+            }
+        }
+    }
+
+    // Reject unless the m-of-n threshold is met
+    if num_signers < usize::from(multisig.m) {
+        log!("Not enough multisig signers for wallet");
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    Ok(())
 }

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -7,11 +7,9 @@ use {
     },
     pinocchio_log::log,
     pinocchio_token_2022::{
-        instructions::{CloseAccount, TransferChecked},
-        state::{Account, Mint, StateWithExtensions},
+        instructions::{CloseAccount, MAX_MULTISIG_SIGNERS, TransferChecked},
+        state::{Account, Mint, Multisig, StateWithExtensions},
     },
-    solana_program_pack::Pack,
-    spl_token_2022_interface::{instruction::MAX_SIGNERS, state::Multisig},
 };
 
 /// Recovers tokens stuck in a "nested" ATA (one that was created by mistakenly using an ATA address
@@ -202,15 +200,19 @@ fn validate_multisig_wallet(
     signer_accounts: &[AccountView],
 ) -> ProgramResult {
     let wallet_data = wallet.try_borrow()?;
-    let multisig = Multisig::unpack(&wallet_data)?;
+    // SAFETY: Function called after wallet data length is confirmed to be
+    // `Multisig::LEN` and is owned by SPL Token or Token-2022.
+    let multisig = unsafe { Multisig::from_bytes_unchecked(&wallet_data) };
+    if !multisig.is_initialized() {
+        return Err(ProgramError::UninitializedAccount);
+    }
 
-    let mut num_signers: usize = 0;
-    let mut matched = [false; MAX_SIGNERS];
-    let signers = &multisig.signers[..usize::from(multisig.n)];
+    let mut num_signers: u8 = 0;
+    let mut matched = [false; MAX_MULTISIG_SIGNERS];
 
     // Count distinct configured signers that signed
     for signer_account in signer_accounts {
-        for (position, signer) in signers.iter().enumerate() {
+        for (position, signer) in multisig.signers().iter().enumerate() {
             // Match on address, skipping signers already credited
             if signer == signer_account.address() && !matched[position] {
                 // A matching account must have signed the transaction
@@ -226,7 +228,7 @@ fn validate_multisig_wallet(
     }
 
     // Reject unless the m-of-n threshold is met
-    if num_signers < usize::from(multisig.m) {
+    if num_signers < multisig.required_signers() {
         log!("Not enough multisig signers for wallet");
         return Err(ProgramError::MissingRequiredSignature);
     }

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -103,7 +103,9 @@ pub(crate) fn process_recover_nested(
 
     // Multisig wallets are authorized by their configured signer accounts.
     // Other wallet accounts must sign directly.
-    if wallet.owned_by(owner_token_program.address()) && wallet.data_len() == Multisig::LEN {
+    if wallet.data_len() == Multisig::LEN
+        && (wallet.owned_by(&pinocchio_token::ID) || wallet.owned_by(&pinocchio_token_2022::ID))
+    {
         let wallet_signers = remaining.get(1..).unwrap_or_default();
         validate_multisig_wallet(wallet, wallet_signers)?;
     } else if !wallet.is_signer() {

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -195,6 +195,7 @@ pub(crate) fn process_recover_nested(
 }
 
 #[inline(always)]
+#[allow(clippy::arithmetic_side_effects)]
 fn validate_multisig_wallet(
     wallet: &AccountView,
     signer_accounts: &[AccountView],
@@ -220,9 +221,7 @@ fn validate_multisig_wallet(
                     return Err(ProgramError::MissingRequiredSignature);
                 }
                 matched[position] = true;
-                num_signers = num_signers
-                    .checked_add(1)
-                    .ok_or(ProgramError::InvalidInstructionData)?;
+                num_signers += 1;
             }
         }
     }

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -195,7 +195,6 @@ pub(crate) fn process_recover_nested(
 }
 
 #[inline(always)]
-#[allow(clippy::arithmetic_side_effects)]
 fn validate_multisig_wallet(
     wallet: &AccountView,
     signer_accounts: &[AccountView],
@@ -221,7 +220,7 @@ fn validate_multisig_wallet(
                     return Err(ProgramError::MissingRequiredSignature);
                 }
                 matched[position] = true;
-                num_signers += 1;
+                num_signers = num_signers.wrapping_add(1);
             }
         }
     }

--- a/pinocchio/program/tests/recover_nested.rs
+++ b/pinocchio/program/tests/recover_nested.rs
@@ -270,6 +270,31 @@ fn fail_token_owned_non_multisig_must_sign() {
     );
 }
 
+#[test]
+fn fail_multisig_len_wallet_with_non_token_owner_must_sign() {
+    let owner_token_program_id = spl_token_interface::id();
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio);
+    let wallet = create_sized_wallet(&mut harness, Address::new_unique(), Multisig::LEN);
+    let setup = recover_nested_setup_for_wallet(
+        harness,
+        wallet,
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let signer = Address::new_unique();
+    setup
+        .harness
+        .ensure_account_exists_with_lamports(signer, 1_000_000);
+    let recover_instruction = build_recover_instruction(&setup, &[&signer]);
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
 // =============== MULTISIG TESTS ===============
 
 fn create_multisig_wallet(
@@ -395,33 +420,6 @@ fn fail_missing_nested_token_program_account_with_signers() {
     );
 }
 
-#[test_case(spl_token_interface::id(), spl_token_2022_interface::id())]
-#[test_case(spl_token_2022_interface::id(), spl_token_interface::id())]
-fn fail_multisig_owned_by_other_token_program(
-    wallet_token_program_id: Address,
-    owner_token_program_id: Address,
-) {
-    let (setup, signers) = multisig_setup(
-        wallet_token_program_id,
-        owner_token_program_id,
-        owner_token_program_id,
-    );
-
-    let recover_instruction = build_recover_nested_instruction(
-        &setup.wallet,
-        &setup.owner_mint,
-        &setup.nested_mint,
-        &owner_token_program_id,
-        &owner_token_program_id,
-        &[&signers[0], &signers[1]],
-    );
-
-    setup.harness.ctx.process_and_validate_instruction(
-        &recover_instruction,
-        &[Check::err(ProgramError::MissingRequiredSignature)],
-    );
-}
-
 #[test_case(spl_token_interface::id())]
 #[test_case(spl_token_2022_interface::id())]
 fn fail_uninitialized_multisig_wallet(owner_token_program_id: Address) {
@@ -543,11 +541,16 @@ fn fail_invalid_multisig_signer_sets(case: InvalidMultisigSignerSet) {
 
 #[test_matrix(
     [spl_token_interface::id(), spl_token_2022_interface::id()],
+    [spl_token_interface::id(), spl_token_2022_interface::id()],
     [spl_token_interface::id(), spl_token_2022_interface::id()]
 )]
-fn success_multisig_wallet(owner_token_program_id: Address, nested_token_program_id: Address) {
+fn success_multisig_wallet(
+    wallet_token_program_id: Address,
+    owner_token_program_id: Address,
+    nested_token_program_id: Address,
+) {
     let (setup, signers) = multisig_setup(
-        owner_token_program_id,
+        wallet_token_program_id,
         owner_token_program_id,
         nested_token_program_id,
     );

--- a/pinocchio/program/tests/recover_nested.rs
+++ b/pinocchio/program/tests/recover_nested.rs
@@ -1,12 +1,18 @@
 use {
     mollusk_svm_result::Check,
     solana_address::Address,
-    solana_instruction::{AccountMeta, Instruction},
+    solana_instruction::Instruction,
     solana_program_error::ProgramError,
-    spl_associated_token_account_interface::address::get_associated_token_address_with_program_id,
-    spl_associated_token_account_mollusk_harness::{AtaProgram, AtaTestHarness},
-    spl_token_2022_interface::{extension::StateWithExtensionsOwned, state::Account},
-    test_case::test_case,
+    solana_program_pack::Pack,
+    solana_rent::Rent,
+    spl_associated_token_account_mollusk_harness::{
+        AtaProgram, AtaTestHarness, build_recover_nested_instruction,
+    },
+    spl_token_2022_interface::{
+        extension::StateWithExtensionsOwned, instruction::initialize_multisig2, state::Account,
+    },
+    spl_token_interface::state::Multisig,
+    test_case::{test_case, test_matrix},
 };
 
 const TEST_MINT_AMOUNT: u64 = 100;
@@ -20,54 +26,32 @@ struct RecoverNestedSetup {
     destination_ata: Address,
 }
 
-// TODO: Need to add to token-program sdk
-fn recover_nested_ix(
-    wallet: Address,
-    owner_mint: Address,
-    nested_mint: Address,
-    owner_token_program_id: Address,
-    nested_token_program_id: Address,
-) -> Instruction {
-    let owner_associated_account_address =
-        get_associated_token_address_with_program_id(&wallet, &owner_mint, &owner_token_program_id);
-    let destination_associated_account_address = get_associated_token_address_with_program_id(
-        &wallet,
-        &nested_mint,
-        &nested_token_program_id,
-    );
-    let nested_associated_account_address = get_associated_token_address_with_program_id(
-        &owner_associated_account_address,
-        &nested_mint,
-        &nested_token_program_id,
-    );
-
-    Instruction {
-        program_id: spl_associated_token_account_interface::program::id(),
-        accounts: vec![
-            AccountMeta::new(nested_associated_account_address, false),
-            AccountMeta::new_readonly(nested_mint, false),
-            AccountMeta::new(destination_associated_account_address, false),
-            AccountMeta::new_readonly(owner_associated_account_address, false),
-            AccountMeta::new_readonly(owner_mint, false),
-            AccountMeta::new(wallet, true),
-            AccountMeta::new_readonly(owner_token_program_id, false),
-            AccountMeta::new_readonly(nested_token_program_id, false),
-        ],
-        data: vec![2],
-    }
-}
-
 // Build a nested ATA layout where the owner and nested accounts can be under
 // different token programs
 fn recover_nested_setup(
     owner_token_program_id: Address,
     nested_token_program_id: Address,
 ) -> RecoverNestedSetup {
-    let mut harness =
+    let harness =
         AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio)
             .with_wallet(1_000_000);
 
     let wallet = harness.wallet.unwrap();
+
+    recover_nested_setup_for_wallet(
+        harness,
+        wallet,
+        owner_token_program_id,
+        nested_token_program_id,
+    )
+}
+
+fn recover_nested_setup_for_wallet(
+    mut harness: AtaTestHarness,
+    wallet: Address,
+    owner_token_program_id: Address,
+    nested_token_program_id: Address,
+) -> RecoverNestedSetup {
     let (owner_mint, _) = harness.create_mint_with_token_program(owner_token_program_id, 0);
     let owner_ata = harness.create_ata_for_owner_with_token_program(
         wallet,
@@ -109,73 +93,12 @@ fn recover_nested_setup(
     }
 }
 
-#[test]
-fn fail_missing_extra_account_when_programs_differ() {
-    let owner_token_program_id = spl_token_interface::id();
-    let nested_token_program_id = spl_token_2022_interface::id();
-    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
-
-    let mut recover_instruction = recover_nested_ix(
-        setup.wallet,
-        setup.owner_mint,
-        setup.nested_mint,
-        owner_token_program_id,
-        nested_token_program_id,
-    );
-
-    // Drop the optional nested token program account
-    recover_instruction.accounts.truncate(7);
-
-    setup.harness.ctx.process_and_validate_instruction(
-        &recover_instruction,
-        &[Check::err(ProgramError::InvalidSeeds)],
-    );
-}
-
-#[test]
-fn fail_wrong_nested_token_program_account() {
-    let owner_token_program_id = spl_token_interface::id();
-    let nested_token_program_id = spl_token_2022_interface::id();
-    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
-
-    let mut recover_instruction = recover_nested_ix(
-        setup.wallet,
-        setup.owner_mint,
-        setup.nested_mint,
-        owner_token_program_id,
-        nested_token_program_id,
-    );
-
-    // Point the nested token program account at the owner program to break PDA derivation
-    recover_instruction.accounts[7].pubkey = owner_token_program_id;
-
-    setup.harness.ctx.process_and_validate_instruction(
-        &recover_instruction,
-        &[Check::err(ProgramError::InvalidSeeds)],
-    );
-}
-
-#[test_case(spl_token_interface::id(), spl_token_interface::id())]
-#[test_case(spl_token_interface::id(), spl_token_2022_interface::id())]
-#[test_case(spl_token_2022_interface::id(), spl_token_interface::id())]
-#[test_case(spl_token_2022_interface::id(), spl_token_2022_interface::id())]
-fn success_mixed_token_programs(owner_token_program_id: Address, nested_token_program_id: Address) {
-    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
-
+fn assert_recover_nested_success(setup: RecoverNestedSetup, recover_instruction: Instruction) {
     let pre_wallet_lamports = {
         let store = setup.harness.ctx.account_store.borrow();
         store.get(&setup.wallet).unwrap().lamports
     };
     let nested_lamports = setup.harness.get_account(setup.nested_ata).lamports;
-
-    let recover_instruction = recover_nested_ix(
-        setup.wallet,
-        setup.owner_mint,
-        setup.nested_mint,
-        owner_token_program_id,
-        nested_token_program_id,
-    );
-    assert_eq!(recover_instruction.accounts.len(), 8);
 
     setup.harness.ctx.process_and_validate_instruction(
         &recover_instruction,
@@ -197,4 +120,494 @@ fn success_mixed_token_programs(owner_token_program_id: Address, nested_token_pr
             .amount,
         TEST_MINT_AMOUNT
     );
+}
+
+#[test]
+fn fail_missing_extra_account_when_programs_differ() {
+    let owner_token_program_id = spl_token_interface::id();
+    let nested_token_program_id = spl_token_2022_interface::id();
+    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
+
+    let mut recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &nested_token_program_id,
+        &[],
+    );
+
+    // Drop the optional nested token program account
+    recover_instruction.accounts.truncate(7);
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::InvalidSeeds)],
+    );
+}
+
+#[test]
+fn fail_wrong_nested_token_program_account() {
+    let owner_token_program_id = spl_token_interface::id();
+    let nested_token_program_id = spl_token_2022_interface::id();
+    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
+
+    let mut recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &nested_token_program_id,
+        &[],
+    );
+
+    // Point the nested token program account at the owner program to break PDA derivation
+    recover_instruction.accounts[7].pubkey = owner_token_program_id;
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::InvalidSeeds)],
+    );
+}
+
+#[test_case(spl_token_interface::id(), spl_token_interface::id())]
+#[test_case(spl_token_interface::id(), spl_token_2022_interface::id())]
+#[test_case(spl_token_2022_interface::id(), spl_token_interface::id())]
+#[test_case(spl_token_2022_interface::id(), spl_token_2022_interface::id())]
+fn success_mixed_token_programs(owner_token_program_id: Address, nested_token_program_id: Address) {
+    let setup = recover_nested_setup(owner_token_program_id, nested_token_program_id);
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &nested_token_program_id,
+        &[],
+    );
+    assert_eq!(
+        recover_instruction.accounts.len(),
+        if owner_token_program_id == nested_token_program_id {
+            7
+        } else {
+            8
+        }
+    );
+
+    assert_recover_nested_success(setup, recover_instruction);
+}
+
+#[test_case(spl_token_interface::id())]
+#[test_case(spl_token_2022_interface::id())]
+fn success_same_token_program_with_redundant_nested_token_program_account(
+    token_program_id: Address,
+) {
+    let setup = recover_nested_setup(token_program_id, token_program_id);
+
+    let mut recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &token_program_id,
+        &token_program_id,
+        &[],
+    );
+    assert_eq!(recover_instruction.accounts.len(), 7);
+    recover_instruction
+        .accounts
+        .push(solana_instruction::AccountMeta::new_readonly(
+            token_program_id,
+            false,
+        ));
+
+    assert_recover_nested_success(setup, recover_instruction);
+}
+
+#[test]
+fn fail_standard_wallet_did_not_sign() {
+    let owner_token_program_id = spl_token_interface::id();
+    let harness =
+        AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio);
+    let setup = recover_nested_setup_for_wallet(
+        harness,
+        Address::new_unique(),
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let mut recover_instruction = build_recover_instruction(&setup, &[]);
+    recover_instruction.accounts[5].is_signer = false;
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test]
+fn fail_token_owned_non_multisig_must_sign() {
+    let owner_token_program_id = spl_token_interface::id();
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio);
+    // Owned by the token program but Account::LEN (not Multisig::LEN)
+    let wallet = create_sized_wallet(&mut harness, owner_token_program_id, Account::LEN);
+    let setup = recover_nested_setup_for_wallet(
+        harness,
+        wallet,
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let signer = Address::new_unique();
+    setup
+        .harness
+        .ensure_account_exists_with_lamports(signer, 1_000_000);
+    let recover_instruction = build_recover_instruction(&setup, &[&signer]);
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+// =============== MULTISIG TESTS ===============
+
+fn create_multisig_wallet(
+    harness: &mut AtaTestHarness,
+    token_program_id: Address,
+    signers: &[Address],
+    required_signers: u8,
+) -> Address {
+    let signer_accounts = signers
+        .iter()
+        .copied()
+        .map(|signer| (signer, 1_000_000))
+        .collect::<Vec<_>>();
+    harness.ensure_accounts_with_lamports(&signer_accounts);
+
+    let multisig = Address::new_unique();
+    let rent_lamports = Rent::default().minimum_balance(Multisig::LEN);
+    let create_multisig_ix = solana_system_interface::instruction::create_account(
+        &harness.payer,
+        &multisig,
+        rent_lamports,
+        Multisig::LEN as u64,
+        &token_program_id,
+    );
+    harness
+        .ctx
+        .process_and_validate_instruction(&create_multisig_ix, &[Check::success()]);
+
+    let signer_refs = signers.iter().collect::<Vec<_>>();
+    let initialize_multisig_ix =
+        initialize_multisig2(&token_program_id, &multisig, &signer_refs, required_signers).unwrap();
+    harness
+        .ctx
+        .process_and_validate_instruction(&initialize_multisig_ix, &[Check::success()]);
+
+    multisig
+}
+
+fn create_sized_wallet(harness: &mut AtaTestHarness, owner: Address, space: usize) -> Address {
+    let wallet = Address::new_unique();
+    let create_wallet_ix = solana_system_interface::instruction::create_account(
+        &harness.payer,
+        &wallet,
+        Rent::default().minimum_balance(space),
+        space as u64,
+        &owner,
+    );
+    harness
+        .ctx
+        .process_and_validate_instruction(&create_wallet_ix, &[Check::success()]);
+    wallet
+}
+
+fn multisig_setup_with_signers(
+    wallet_token_program_id: Address,
+    owner_token_program_id: Address,
+    nested_token_program_id: Address,
+    signers: &[Address],
+    required_signers: u8,
+) -> RecoverNestedSetup {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio);
+    let wallet = create_multisig_wallet(
+        &mut harness,
+        wallet_token_program_id,
+        signers,
+        required_signers,
+    );
+    recover_nested_setup_for_wallet(
+        harness,
+        wallet,
+        owner_token_program_id,
+        nested_token_program_id,
+    )
+}
+
+fn multisig_setup(
+    wallet_token_program_id: Address,
+    owner_token_program_id: Address,
+    nested_token_program_id: Address,
+) -> (RecoverNestedSetup, [Address; 3]) {
+    let signers = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    let setup = multisig_setup_with_signers(
+        wallet_token_program_id,
+        owner_token_program_id,
+        nested_token_program_id,
+        &signers,
+        2,
+    );
+    (setup, signers)
+}
+
+fn build_recover_instruction(setup: &RecoverNestedSetup, signers: &[&Address]) -> Instruction {
+    build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &spl_token_interface::id(),
+        &spl_token_interface::id(),
+        signers,
+    )
+}
+
+#[test]
+fn fail_missing_nested_token_program_account_with_signers() {
+    let (setup, signers) = multisig_setup(
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+    );
+
+    let mut recover_instruction = build_recover_instruction(&setup, &[&signers[0], &signers[1]]);
+    // Drop the nested token program account so the first signer lands in its slot
+    recover_instruction.accounts.remove(7);
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::InvalidSeeds)],
+    );
+}
+
+#[test_case(spl_token_interface::id(), spl_token_2022_interface::id())]
+#[test_case(spl_token_2022_interface::id(), spl_token_interface::id())]
+fn fail_multisig_owned_by_other_token_program(
+    wallet_token_program_id: Address,
+    owner_token_program_id: Address,
+) {
+    let (setup, signers) = multisig_setup(
+        wallet_token_program_id,
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &owner_token_program_id,
+        &[&signers[0], &signers[1]],
+    );
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test_case(spl_token_interface::id())]
+#[test_case(spl_token_2022_interface::id())]
+fn fail_uninitialized_multisig_wallet(owner_token_program_id: Address) {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&owner_token_program_id, AtaProgram::Pinocchio);
+    let wallet = create_sized_wallet(&mut harness, owner_token_program_id, Multisig::LEN);
+    let setup = recover_nested_setup_for_wallet(
+        harness,
+        wallet,
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &owner_token_program_id,
+        &[],
+    );
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::UninitializedAccount)],
+    );
+}
+
+#[test]
+fn fail_matched_signer_account_did_not_sign() {
+    let signers = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    let setup = multisig_setup_with_signers(
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        &signers,
+        1,
+    );
+
+    let mut recover_instruction = build_recover_instruction(&setup, &[&signers[0], &signers[1]]);
+    recover_instruction
+        .accounts
+        .iter_mut()
+        .find(|account| account.pubkey == signers[1])
+        .unwrap()
+        .is_signer = false;
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test_case(spl_token_interface::id())]
+#[test_case(spl_token_2022_interface::id())]
+fn fail_signed_multisig_wallet_without_signer_accounts(owner_token_program_id: Address) {
+    let (setup, _) = multisig_setup(
+        owner_token_program_id,
+        owner_token_program_id,
+        owner_token_program_id,
+    );
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &owner_token_program_id,
+        &[],
+    );
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+enum InvalidMultisigSignerSet {
+    InsufficientSigners,
+    UnknownSigner,
+    DuplicateSignerAccount,
+}
+
+#[test_case(InvalidMultisigSignerSet::InsufficientSigners)]
+#[test_case(InvalidMultisigSignerSet::UnknownSigner)]
+#[test_case(InvalidMultisigSignerSet::DuplicateSignerAccount)]
+fn fail_invalid_multisig_signer_sets(case: InvalidMultisigSignerSet) {
+    let (setup, signers) = multisig_setup(
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+    );
+    let unknown_signer = Address::new_unique();
+    setup
+        .harness
+        .ensure_account_exists_with_lamports(unknown_signer, 1_000_000);
+
+    let recover_instruction = match case {
+        InvalidMultisigSignerSet::InsufficientSigners => {
+            build_recover_instruction(&setup, &[&signers[0]])
+        }
+        InvalidMultisigSignerSet::UnknownSigner => {
+            build_recover_instruction(&setup, &[&signers[0], &unknown_signer])
+        }
+        InvalidMultisigSignerSet::DuplicateSignerAccount => {
+            build_recover_instruction(&setup, &[&signers[0], &signers[0]])
+        }
+    };
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test_matrix(
+    [spl_token_interface::id(), spl_token_2022_interface::id()],
+    [spl_token_interface::id(), spl_token_2022_interface::id()]
+)]
+fn success_multisig_wallet(owner_token_program_id: Address, nested_token_program_id: Address) {
+    let (setup, signers) = multisig_setup(
+        owner_token_program_id,
+        owner_token_program_id,
+        nested_token_program_id,
+    );
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &setup.nested_mint,
+        &owner_token_program_id,
+        &nested_token_program_id,
+        &[&signers[2], &signers[0]],
+    );
+
+    assert_recover_nested_success(setup, recover_instruction);
+}
+
+#[test]
+fn success_duplicate_multisig_slots_satisfied_by_one_account() {
+    let duplicated = Address::new_unique();
+    let signers = [duplicated, duplicated, Address::new_unique()];
+    let setup = multisig_setup_with_signers(
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        &signers,
+        2,
+    );
+
+    let recover_instruction = build_recover_instruction(&setup, &[&duplicated]);
+
+    assert_recover_nested_success(setup, recover_instruction);
+}
+
+#[test]
+fn success_extra_signer_accounts_ignored() {
+    let signers = [
+        Address::new_unique(),
+        Address::new_unique(),
+        Address::new_unique(),
+    ];
+    let setup = multisig_setup_with_signers(
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        spl_token_interface::id(),
+        &signers,
+        1,
+    );
+    let unknown_signer = Address::new_unique();
+    setup
+        .harness
+        .ensure_account_exists_with_lamports(unknown_signer, 1_000_000);
+
+    let mut recover_instruction =
+        build_recover_instruction(&setup, &[&unknown_signer, &signers[0], &signers[2]]);
+    recover_instruction
+        .accounts
+        .iter_mut()
+        .find(|account| account.pubkey == unknown_signer)
+        .unwrap()
+        .is_signer = false;
+
+    assert_recover_nested_success(setup, recover_instruction);
 }


### PR DESCRIPTION
Addresses https://github.com/solana-program/associated-token-account/issues/24

Adds multisig wallet support to the pinocchio `RecoverNested` instruction, matching the spl-token/t22 authorization model. A wallet that is an initialized multisig is now authorized by its configured M-of-N signer accounts rather than a direct signature.