### PR TITLE
p-ata: Use bump hint on idempotent no-op path

### DIFF
--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,4 +1,4 @@
-#### 2026-06-24 08:20:07.379346 UTC
+#### 2026-06-25 16:04:39.216202 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
 
@@ -13,9 +13,9 @@ Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agav
 | create_idempotent (new, token-2022) | 5496 | -- |
 | create_with_args_idempotent (new, token-2022) | 5295 | -10 |
 | create_idempotent (existing, spl-token) | 530 | -1 |
-| create_with_args_idempotent (existing, spl-token) | 548 | -44 |
+| create_with_args_idempotent (existing, spl-token) | 387 | -205 |
 | create_idempotent (existing, token-2022) | 1616 | -1 |
-| create_with_args_idempotent (existing, token-2022) | 1634 | -47 |
+| create_with_args_idempotent (existing, token-2022) | 387 | -1,294 |
 | create (prefunded, spl-token) | 3085 | -1 |
 | create_with_args (prefunded, spl-token) | 2831 | -11 |
 | create (prefunded, token-2022) | 5132 | -2 |

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,32 @@
+#### 2026-06-24 08:20:07.379346 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3085 | -1 |
+| create_with_args (spl-token) | 2831 | -11 |
+| create (token-2022) | 5132 | -2 |
+| create_with_args (token-2022) | 4925 | -11 |
+| create_idempotent (new, spl-token) | 4171 | -1 |
+| create_with_args_idempotent (new, spl-token) | 3925 | -10 |
+| create_idempotent (new, token-2022) | 5496 | -- |
+| create_with_args_idempotent (new, token-2022) | 5295 | -10 |
+| create_idempotent (existing, spl-token) | 530 | -1 |
+| create_with_args_idempotent (existing, spl-token) | 548 | -44 |
+| create_idempotent (existing, token-2022) | 1616 | -1 |
+| create_with_args_idempotent (existing, token-2022) | 1634 | -47 |
+| create (prefunded, spl-token) | 3085 | -1 |
+| create_with_args (prefunded, spl-token) | 2831 | -11 |
+| create (prefunded, token-2022) | 5132 | -2 |
+| create_with_args (prefunded, token-2022) | 4925 | -11 |
+| create (token-2022 known mint) | 6674 | -2 |
+| create_with_args (token-2022 extended mint) | 5741 | -11 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5148 | -1 |
+| recover_nested (owner=token-2022, nested=token-2022) | 7012 | -1 |
+| recover_nested (owner=spl-token, nested=token-2022) | 9568 | -1 |
+| recover_nested (owner=token-2022, nested=spl-token) | 5518 | -1 |
+
 #### 2026-06-23 17:03:10.291552 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -51,14 +51,25 @@ pub(crate) fn process_create_associated_token_account(
                     if token_account.base.mint() != mint.address() {
                         return Err(ProgramError::InvalidAccountData);
                     }
-                    // Passed bump hints are ignored in this codepath given they are not needed
-                    // in the idempotent+existing path w/ validation below
-                    let derived_ata_addr = AssociatedTokenPda::derive_address(
-                        program_id,
-                        wallet.address(),
-                        token_program.address(),
-                        mint.address(),
-                    );
+                    // Validate expected address, using bump hint if provided
+                    let derived_ata_addr = if let Some(bump) = bump_hint {
+                        Address::derive_address(
+                            &[
+                                wallet.address().as_array(),
+                                token_program.address().as_array(),
+                                mint.address().as_array(),
+                            ],
+                            Some(bump),
+                            program_id,
+                        )
+                    } else {
+                        AssociatedTokenPda::derive_address(
+                            program_id,
+                            wallet.address(),
+                            token_program.address(),
+                            mint.address(),
+                        )
+                    };
                     if derived_ata_addr != *associated_token_account.address() {
                         return Err(ProgramError::InvalidSeeds);
                     }

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -53,6 +53,9 @@ pub(crate) fn process_create_associated_token_account(
                     }
                     // Validate expected address, using bump hint if provided
                     let derived_ata_addr = if let Some(bump) = bump_hint {
+                        // When a `bump` is provided, the address is derived directly without performing
+                        // an on-curve check, since the account already exists. An ATA cannot be created
+                        // with either a non-canonical bump or an on-curve address.
                         Address::derive_address(
                             &[
                                 wallet.address().as_array(),

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -33,6 +33,42 @@ pub(crate) fn process_create_associated_token_account(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
+    // For `CreateIdempotent`, if the ATA already exists and is valid, it's a no-op
+    if create_mode == CreateMode::Idempotent
+        // Preexisting ATA must already be owned by the requested token program
+        && associated_token_account.owned_by(token_program.address())
+    {
+        let ata_data = associated_token_account.try_borrow()?;
+        // Preexisting ATA must be parsable as a token account
+        if let Ok(token_account) = StateWithExtensions::<Account>::from_bytes(&ata_data) {
+            // Preexisting ATA cannot be in the uninitialized state
+            if let Ok(account_state) = token_account.base.state() {
+                if account_state != AccountState::Uninitialized {
+                    // Must match the wallet and mint supplied
+                    if token_account.base.owner() != wallet.address() {
+                        return Err(AssociatedTokenAccountError::InvalidOwner.into());
+                    }
+                    if token_account.base.mint() != mint.address() {
+                        return Err(ProgramError::InvalidAccountData);
+                    }
+                    // Passed bump hints are ignored in this codepath given they are not needed
+                    // in the idempotent+existing path w/ validation below
+                    let derived_ata_addr = AssociatedTokenPda::derive_address(
+                        program_id,
+                        wallet.address(),
+                        token_program.address(),
+                        mint.address(),
+                    );
+                    if derived_ata_addr != *associated_token_account.address() {
+                        return Err(ProgramError::InvalidSeeds);
+                    }
+                    // Confirmed `CreateIdempotent` no-op
+                    return Ok(());
+                }
+            }
+        }
+    }
+
     let rent_sysvar = if accept_rent_sysvar {
         // `CreateWithArgs` accepts rent as an optional account
         remaining.first()
@@ -61,38 +97,6 @@ pub(crate) fn process_create_associated_token_account(
     };
     if derived_ata_addr != *associated_token_account.address() {
         return Err(ProgramError::InvalidSeeds);
-    }
-
-    // For `CreateIdempotent`, if the ATA already exists and is valid, it's a no-op
-    if create_mode == CreateMode::Idempotent
-        // Preexisting ATA must already be owned by the requested token program
-        && associated_token_account.owned_by(token_program.address())
-    {
-        let ata_data = associated_token_account.try_borrow()?;
-        // Preexisting ATA must be parsable as a token account
-        if let Ok(token_account) = StateWithExtensions::<Account>::from_bytes(&ata_data) {
-            // Preexisting ATA cannot be in the uninitialized state
-            if let Ok(account_state) = token_account.base.state() {
-                if account_state != AccountState::Uninitialized {
-                    // Now that ATA is confirmed, it must match the wallet and mint supplied
-                    if token_account.base.owner() != wallet.address() {
-                        return Err(AssociatedTokenAccountError::InvalidOwner.into());
-                    }
-                    if token_account.base.mint() != mint.address() {
-                        return Err(ProgramError::InvalidAccountData);
-                    }
-                    // `derive_address_with_bump_hint()` rejects higher off-curve bumps but
-                    // doesn't check whether the hinted bump itself is off-curve. Create paths
-                    // validate that through `invoke_signed()`, but this no-op path returns early,
-                    // so check it here.
-                    if bump_hint.is_some() && derived_ata_addr.is_on_curve() {
-                        return Err(ProgramError::InvalidSeeds);
-                    }
-                    // Confirmed `CreateIdempotent` no-op
-                    return Ok(());
-                }
-            }
-        }
     }
 
     if !associated_token_account.owned_by(&pinocchio_system::ID) {

--- a/pinocchio/program/tests/bump.rs
+++ b/pinocchio/program/tests/bump.rs
@@ -318,3 +318,28 @@ fn create_with_args_idempotent_accepts_existing_ata_with_canonical_bump_hint(
         .ctx
         .process_and_validate_instruction(&instruction, &[Check::success()]);
 }
+
+#[test_matrix([spl_token_interface::id(), spl_token_2022_interface::id()])]
+fn create_with_args_idempotent_accepts_existing_ata_with_wrong_bump_hint(
+    token_program_id: Address,
+) {
+    let mut harness =
+        AtaTestHarness::new_with_ata_program(&token_program_id, AtaProgram::Pinocchio)
+            .with_wallet_and_mint(1_000_000, 6);
+    let wallet = harness.wallet.unwrap();
+    let bump = expected_bump(&harness);
+    let wrong_bump = if bump == 1 { 2 } else { 1 };
+    harness.insert_token_account_at_ata_address(wallet);
+
+    let instruction =
+        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
+            mode: CreateMode::Idempotent,
+            bump: Some(wrong_bump),
+            account_len: None,
+            rent_sysvar: false,
+        });
+
+    harness
+        .ctx
+        .process_and_validate_instruction(&instruction, &[Check::success()]);
+}

--- a/pinocchio/program/tests/bump.rs
+++ b/pinocchio/program/tests/bump.rs
@@ -171,9 +171,8 @@ fn create_with_args_rejects_canonical_bump_hint_for_wrong_ata_account() {
         .process_and_validate_instruction(&instruction, &[Check::err(ProgramError::InvalidSeeds)]);
 }
 
-#[test_case(CreateMode::Idempotent)]
-#[test_case(CreateMode::Always)]
-fn create_with_args_rejects_on_curve_bump_hint(mode: CreateMode) {
+#[test]
+fn create_with_args_rejects_on_curve_bump_hint() {
     let token_program_id = spl_token_interface::id();
     let mut harness = create_mint_account(&token_program_id);
 
@@ -201,37 +200,21 @@ fn create_with_args_rejects_on_curve_bump_hint(mode: CreateMode) {
     harness.ensure_account_exists_with_lamports(wallet, 1_000_000);
     harness.wallet = Some(wallet);
 
-    if mode == CreateMode::Idempotent {
-        harness.ctx.account_store.borrow_mut().insert(
-            on_curve_bump_addr,
-            AccountBuilder::token_account(&MINT, &wallet, 0, &token_program_id),
-        );
-    }
     let mut instruction =
         harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
-            mode,
+            mode: CreateMode::Always,
             bump: Some(attack_bump),
             account_len: None,
             rent_sysvar: false,
         });
     instruction.accounts[1] = AccountMeta::new(on_curve_bump_addr, false);
 
-    match mode {
-        CreateMode::Idempotent => {
-            harness.ctx.process_and_validate_instruction(
-                &instruction,
-                &[Check::err(ProgramError::InvalidSeeds)],
-            );
-        }
-        CreateMode::Always => {
-            harness.ctx.process_and_validate_instruction(
-                &instruction,
-                &[Check::instruction_err(
-                    InstructionError::ProgramFailedToComplete,
-                )],
-            );
-        }
-    }
+    harness.ctx.process_and_validate_instruction(
+        &instruction,
+        &[Check::instruction_err(
+            InstructionError::ProgramFailedToComplete,
+        )],
+    );
 }
 
 #[test_matrix(
@@ -310,31 +293,6 @@ fn create_with_args_idempotent_accepts_existing_ata_with_canonical_bump_hint(
         harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
             mode: CreateMode::Idempotent,
             bump: Some(bump),
-            account_len: None,
-            rent_sysvar: false,
-        });
-
-    harness
-        .ctx
-        .process_and_validate_instruction(&instruction, &[Check::success()]);
-}
-
-#[test_matrix([spl_token_interface::id(), spl_token_2022_interface::id()])]
-fn create_with_args_idempotent_accepts_existing_ata_with_wrong_bump_hint(
-    token_program_id: Address,
-) {
-    let mut harness =
-        AtaTestHarness::new_with_ata_program(&token_program_id, AtaProgram::Pinocchio)
-            .with_wallet_and_mint(1_000_000, 6);
-    let wallet = harness.wallet.unwrap();
-    let bump = expected_bump(&harness);
-    let wrong_bump = if bump == 255 { 254 } else { 255 };
-    harness.insert_token_account_at_ata_address(wallet);
-
-    let instruction =
-        harness.build_create_ata_instruction(CreateAtaInstructionType::CreateWithArgs {
-            mode: CreateMode::Idempotent,
-            bump: Some(wrong_bump),
             account_len: None,
             rent_sysvar: false,
         });

--- a/pinocchio/program/tests/bump.rs
+++ b/pinocchio/program/tests/bump.rs
@@ -328,7 +328,7 @@ fn create_with_args_idempotent_accepts_existing_ata_with_wrong_bump_hint(
             .with_wallet_and_mint(1_000_000, 6);
     let wallet = harness.wallet.unwrap();
     let bump = expected_bump(&harness);
-    let wrong_bump = if bump == 1 { 2 } else { 1 };
+    let wrong_bump = if bump == 255 { 254 } else { 255 };
     harness.insert_token_account_at_ata_address(wallet);
 
     let instruction =


### PR DESCRIPTION
This PR optimizes `CreateWithArgs` by making the idempotent + existing ATA path return earlier while still honoring the bump hint when one is provided.

The main insight is that `derive_address_with_bump_hint()` is only needed on the create/signing path, where the program must validate that the hinted bump is a valid PDA bump before signing. For an already-existing ATA, the program only needs to verify that the supplied account is the expected address.

### Impact

| Path | Before | After | Delta |
|---|---:|---:|---:|
| `create_with_args_idempotent (existing, spl-token)` | 592 | 387 | -205 CU |
| `create_with_args_idempotent (existing, token-2022)` | 1681 | 387 | -1294 CU |
