### PR TITLE
p-ata: `InitializeAccount` for t22 if rent passed 

### DIFF
--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,32 @@
+#### 2026-06-29 05:41:59.572634 UTC
+
+Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3085 | -- |
+| create_with_args (spl-token) | 2831 | -- |
+| create (token-2022) | 5132 | -- |
+| create_with_args (token-2022) | 5314 | +389 |
+| create_idempotent (new, spl-token) | 4171 | -- |
+| create_with_args_idempotent (new, spl-token) | 3925 | -- |
+| create_idempotent (new, token-2022) | 5496 | -- |
+| create_with_args_idempotent (new, token-2022) | 5684 | +389 |
+| create_idempotent (existing, spl-token) | 530 | -- |
+| create_with_args_idempotent (existing, spl-token) | 387 | -- |
+| create_idempotent (existing, token-2022) | 1616 | -- |
+| create_with_args_idempotent (existing, token-2022) | 387 | -- |
+| create (prefunded, spl-token) | 3085 | -- |
+| create_with_args (prefunded, spl-token) | 2831 | -- |
+| create (prefunded, token-2022) | 5132 | -- |
+| create_with_args (prefunded, token-2022) | 5314 | +389 |
+| create (token-2022 known mint) | 6674 | -- |
+| create_with_args (token-2022 extended mint) | 6130 | +389 |
+| recover_nested (owner=spl-token, nested=spl-token) | 5152 | -- |
+| recover_nested (owner=token-2022, nested=token-2022) | 7016 | -- |
+| recover_nested (owner=spl-token, nested=token-2022) | 9572 | -- |
+| recover_nested (owner=token-2022, nested=spl-token) | 5522 | -- |
+
 #### 2026-06-26 14:26:58.508025 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/src/batch.rs
+++ b/pinocchio/program/src/batch.rs
@@ -6,15 +6,27 @@ use {
         instruction::{InstructionAccount, InstructionView},
     },
     pinocchio_token::instructions::{
-        Batch, InitializeAccount3, InitializeImmutableOwner, IntoBatch,
+        Batch, InitializeAccount, InitializeAccount3, InitializeImmutableOwner, IntoBatch,
     },
 };
 
-const DATA_LEN: usize =
-    Batch::header_data_len(2) + InitializeImmutableOwner::DATA_LEN + InitializeAccount3::DATA_LEN;
-const ACCOUNTS_LEN: usize =
-    InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount3::ACCOUNTS_LEN;
+struct BatchLens {
+    data: usize,
+    accounts: usize,
+}
 
+const INIT_WITH_ACCOUNT: BatchLens = BatchLens {
+    data: Batch::header_data_len(2)
+        + InitializeImmutableOwner::DATA_LEN
+        + InitializeAccount::DATA_LEN,
+    accounts: InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount::ACCOUNTS_LEN,
+};
+const INIT_WITH_ACCOUNT3: BatchLens = BatchLens {
+    data: Batch::header_data_len(2)
+        + InitializeImmutableOwner::DATA_LEN
+        + InitializeAccount3::DATA_LEN,
+    accounts: InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount3::ACCOUNTS_LEN,
+};
 // TODO: `pinocchio-token` v0.6 provides a Batch builder but its `invoke()` method hardcodes
 //       SPL Token's program ID. `pinocchio-token-2022` does not yet offer its own batch builder.
 //       Once it does, this can be replaced.
@@ -23,18 +35,30 @@ pub(crate) fn batch_init_and_lock_owner(
     token_program: &Address,
     account: &AccountView,
     mint: &AccountView,
-    owner: &Address,
+    owner: &AccountView,
+    rent_sysvar: Option<&AccountView>,
 ) -> ProgramResult {
-    // Buffers sized for exactly two sub-instructions
-    let mut data = [const { MaybeUninit::<u8>::uninit() }; DATA_LEN];
+    // `InitializeAccount3` has the larger data payload, `InitializeAccount` has
+    // the larger account list because it includes the rent sysvar.
+    let mut data = [const { MaybeUninit::<u8>::uninit() }; INIT_WITH_ACCOUNT3.data];
     let mut instruction_accounts =
-        [const { MaybeUninit::<InstructionAccount>::uninit() }; ACCOUNTS_LEN];
-    let mut accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; ACCOUNTS_LEN];
+        [const { MaybeUninit::<InstructionAccount>::uninit() }; INIT_WITH_ACCOUNT.accounts];
+    let mut cpi_accounts =
+        [const { MaybeUninit::<CpiAccount>::uninit() }; INIT_WITH_ACCOUNT.accounts];
 
     // Serialize both sub-instructions into the buffers
-    let mut batch = Batch::new(&mut data, &mut instruction_accounts, &mut accounts)?;
+    let mut batch = Batch::new(&mut data, &mut instruction_accounts, &mut cpi_accounts)?;
     InitializeImmutableOwner::new(account).into_batch(&mut batch)?;
-    InitializeAccount3::new(account, mint, owner).into_batch(&mut batch)?;
+    let lens = match rent_sysvar {
+        Some(rent_sysvar) => {
+            InitializeAccount::new(account, mint, owner, rent_sysvar).into_batch(&mut batch)?;
+            INIT_WITH_ACCOUNT
+        }
+        None => {
+            InitializeAccount3::new(account, mint, owner.address()).into_batch(&mut batch)?;
+            INIT_WITH_ACCOUNT3
+        }
+    };
 
     // Mirrors `Batch::invoke_signed()` but with a supplied program id:
     // https://github.com/anza-xyz/pinocchio/blob/pinocchio-token%40v0.6.0/programs/token/src/instructions/batch.rs#L92-L105
@@ -42,10 +66,10 @@ pub(crate) fn batch_init_and_lock_owner(
         invoke_unchecked(
             &InstructionView {
                 program_id: token_program,
-                accounts: from_raw_parts(instruction_accounts.as_ptr() as _, ACCOUNTS_LEN),
-                data: from_raw_parts(data.as_ptr() as _, DATA_LEN),
+                accounts: from_raw_parts(instruction_accounts.as_ptr() as _, lens.accounts),
+                data: from_raw_parts(data.as_ptr() as _, lens.data),
             },
-            from_raw_parts(accounts.as_ptr() as _, ACCOUNTS_LEN),
+            from_raw_parts(cpi_accounts.as_ptr().cast(), lens.accounts),
         );
     }
 

--- a/pinocchio/program/src/create.rs
+++ b/pinocchio/program/src/create.rs
@@ -156,7 +156,8 @@ pub(crate) fn process_create_associated_token_account(
             token_program.address(),
             associated_token_account,
             mint,
-            wallet.address(),
+            wallet,
+            rent_sysvar,
         )
     } else if let Some(rent) = rent_sysvar {
         // If rent account was supplied, save CUs by passing it into plain `InitializeAccount`.

--- a/pinocchio/program/tests/create_with_args.rs
+++ b/pinocchio/program/tests/create_with_args.rs
@@ -4,6 +4,7 @@ use {
     common::expected_bump,
     mollusk_svm_result::Check,
     pinocchio_associated_token_account_interface::instruction::CreateMode,
+    pinocchio_token::instructions::{Batch, InitializeAccount, InitializeImmutableOwner},
     solana_address::Address,
     solana_instruction::AccountMeta,
     solana_program_error::ProgramError,
@@ -31,6 +32,16 @@ fn expected_rent_exempt_balance(token_program_id: &Address) -> u64 {
         token_account_rent_exempt_balance()
     }
 }
+
+const TOKEN_2022_RENT_INIT_BATCH_DATA: &[u8] = &[
+    Batch::DISCRIMINATOR,
+    InitializeImmutableOwner::ACCOUNTS_LEN as u8,
+    InitializeImmutableOwner::DATA_LEN as u8,
+    InitializeImmutableOwner::DISCRIMINATOR,
+    InitializeAccount::ACCOUNTS_LEN as u8,
+    InitializeAccount::DATA_LEN as u8,
+    InitializeAccount::DISCRIMINATOR,
+];
 
 #[test_matrix([spl_token_interface::id(), spl_token_2022_interface::id()])]
 fn create_with_args_idempotent_accepts_existing_ata(token_program_id: Address) {
@@ -140,7 +151,7 @@ fn create_with_args_accepts_optional_inputs(
         });
     let ata_address = harness.ata_address.unwrap();
 
-    harness.ctx.process_and_validate_instruction(
+    let result = harness.ctx.process_and_validate_instruction(
         &instruction,
         &[
             Check::success(),
@@ -151,6 +162,12 @@ fn create_with_args_accepts_optional_inputs(
                 .build(),
         ],
     );
+
+    if token_program_id == spl_token_2022_interface::id() && rent_sysvar {
+        assert!(result.inner_instructions.iter().any(|inner_instruction| {
+            inner_instruction.instruction.data.as_slice() == TOKEN_2022_RENT_INIT_BATCH_DATA
+        }));
+    }
 }
 
 #[test_matrix(


### PR DESCRIPTION
Follow up to: https://github.com/solana-program/associated-token-account/pull/275#issuecomment-4789289490

For token-2022, it's currently [not using a performant conversion](https://github.com/solana-program/token-2022/blob/635262cb38af4effd567292fc061c617ddf67a90/program/src/processor.rs#L187-L188) for rent sysvar account parsing. Currently this will result in worse performance for ATA program (+389 CUs on the t22 create path), but after t22 program gets updated, it will result in better-than-InitializeAccountV3 performance. 