### PR TITLE
feat(interface): deprecate `get_associated_token_address`

### DIFF
--- a/interface/src/address.rs
+++ b/interface/src/address.rs
@@ -24,6 +24,11 @@ mod inline_spl_token {
 
 /// Derives the associated token account address for the given wallet address
 /// and token mint
+#[deprecated(
+    since = "2.1.0",
+    note = "Use `get_associated_token_address_with_program_id` instead. This function assumes the \
+            SPL Token program, which does not work for Token-2022 mints."
+)]
 pub fn get_associated_token_address(
     wallet_address: &Pubkey,
     token_mint_address: &Pubkey,

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -13,6 +13,7 @@ pub mod tools;
     note = "Use `spl_associated_token_account_interface::address` instead and remove \
             `spl_associated_token_account` as a dependency"
 )]
+#[allow(deprecated)]
 pub use spl_associated_token_account_interface::address::{
     get_associated_token_address, get_associated_token_address_with_program_id,
 };
@@ -39,6 +40,7 @@ use {
     since = "1.0.5",
     note = "please use `instruction::create_associated_token_account` instead"
 )]
+#[allow(deprecated)]
 pub fn create_associated_token_account(
     funding_address: &Pubkey,
     wallet_address: &Pubkey,


### PR DESCRIPTION
Closes #96. As @joncinque suggested, marking `get_associated_token_address` as deprecated.

It silently hardcodes the classic SPL Token program id, which trips up Token-2022 users. The deprecation points them to `get_associated_token_address_with_program_id` (explicit program id). The two internal usages in the program crate (the re-export and the already-deprecated `create_associated_token_account`) get `#[allow(deprecated)]` so the build stays warning-clean.

One thing: I set `since = "2.1.0"` (next minor after the published 2.0.0). Let me know if you'd prefer a different version.
