### PR TITLE
p-ata: Update pinocchio-token crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,7 +1816,7 @@ dependencies = [
 [[package]]
 name = "pinocchio"
 version = "0.11.2"
-source = "git+https://github.com/anza-xyz/pinocchio?rev=4992a8be006c899d125bd2cd5f9eaab6ef6a2884#4992a8be006c899d125bd2cd5f9eaab6ef6a2884"
+source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -1850,7 +1850,7 @@ dependencies = [
  "pinocchio-associated-token-account-interface",
  "pinocchio-log",
  "pinocchio-system",
- "pinocchio-token",
+ "pinocchio-token 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pinocchio-token-2022",
  "solana-account",
  "solana-address 2.6.1",
@@ -1911,10 +1911,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pinocchio-token"
+version = "0.6.0"
+source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
+dependencies = [
+ "solana-account-view",
+ "solana-address 2.6.1",
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
 name = "pinocchio-token-2022"
 version = "0.3.1"
-source = "git+https://github.com/anza-xyz/pinocchio?rev=4992a8be006c899d125bd2cd5f9eaab6ef6a2884#4992a8be006c899d125bd2cd5f9eaab6ef6a2884"
+source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
 dependencies = [
+ "pinocchio-token 0.6.0 (git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022)",
  "solana-account-view",
  "solana-address 2.6.1",
  "solana-instruction-view",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,21 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "pinocchio"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d707cea2843c1a2fd8ec49e4116ce3fdaedcd552a3ee168b03ce60e627fc0f62"
-dependencies = [
- "solana-account-view",
- "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
- "solana-instruction-view",
- "solana-program-error",
-]
-
-[[package]]
-name = "pinocchio"
 version = "0.11.2"
-source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cababcb62a2e739c7078ae16eda02789a6e3edd21bbdded864e85c38a7914d"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -1831,7 +1819,7 @@ version = "0.1.0"
 dependencies = [
  "codama",
  "codama-macros",
- "pinocchio 0.11.2",
+ "pinocchio",
  "solana-address 2.6.1",
  "solana-nullable",
  "solana-zero-copy",
@@ -1846,11 +1834,11 @@ dependencies = [
  "mollusk-svm-bencher",
  "mollusk-svm-programs-token",
  "mollusk-svm-result",
- "pinocchio 0.11.2",
+ "pinocchio",
  "pinocchio-associated-token-account-interface",
  "pinocchio-log",
  "pinocchio-system",
- "pinocchio-token 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pinocchio-token",
  "pinocchio-token-2022",
  "solana-account",
  "solana-address 2.6.1",
@@ -1894,26 +1882,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ae2ee67b42e2ac797dd88312da473c895660e270d8093e0ba2749b885b5778"
 dependencies = [
- "pinocchio 0.11.1",
+ "pinocchio",
  "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "pinocchio-token"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825f59c8348e5c2d3fd56432ef927f5819542b3b05fae4f5b6869801113e775e"
-dependencies = [
- "solana-account-view",
- "solana-address 2.6.1",
- "solana-instruction-view",
- "solana-program-error",
-]
-
-[[package]]
-name = "pinocchio-token"
-version = "0.6.0"
-source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
+checksum = "217e3259f93a1520e4692b18653dad4d29af54ffc8b3a09819808be85dada074"
 dependencies = [
  "solana-account-view",
  "solana-address 2.6.1",
@@ -1923,10 +1900,11 @@ dependencies = [
 
 [[package]]
 name = "pinocchio-token-2022"
-version = "0.3.1"
-source = "git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022#346d0c6d65c17ae9f8abea959e864e5c56ef5835"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3c164973916f044bebff3c8cb4467088bafb13cbdb818522b9ca8782940d06"
 dependencies = [
- "pinocchio-token 0.6.0 (git+https://github.com/febo/pinocchio-fork.git?branch=generic-token2022)",
+ "pinocchio-token",
  "solana-account-view",
  "solana-address 2.6.1",
  "solana-instruction-view",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = ["interface", "program", "mollusk_harness", "pinocchio/interface", "pi
 [workspace.dependencies]
 # TODO: Waiting on PR #349 to merge and then be released: https://github.com/anza-xyz/pinocchio/pull/349.
 #       We need StateWithExtensions API from that PR.
-pinocchio = { version = "0.11.2", git = "https://github.com/anza-xyz/pinocchio", rev = "4992a8be006c899d125bd2cd5f9eaab6ef6a2884" }
-pinocchio-token-2022 = { version = "0.3.1", git = "https://github.com/anza-xyz/pinocchio", rev = "4992a8be006c899d125bd2cd5f9eaab6ef6a2884" }
+pinocchio = { version = "0.11.2", git = "https://github.com/febo/pinocchio-fork.git", branch = "generic-token2022" }
+pinocchio-token-2022 = { version = "0.3.1", git = "https://github.com/febo/pinocchio-fork.git", branch = "generic-token2022" }
 
 # TODO: Requires bumping to mollusk beta due to dependency requirements on token-2022-interface v3.1.
 #       It needs solana-instruction v3.4 while mollusk v0.13 requires solana-instruction <3.4.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,8 @@ resolver = "2"
 members = ["interface", "program", "mollusk_harness", "pinocchio/interface", "pinocchio/program"]
 
 [workspace.dependencies]
-# TODO: Waiting on PR #349 to merge and then be released: https://github.com/anza-xyz/pinocchio/pull/349.
-#       We need StateWithExtensions API from that PR.
-pinocchio = { version = "0.11.2", git = "https://github.com/febo/pinocchio-fork.git", branch = "generic-token2022" }
-pinocchio-token-2022 = { version = "0.3.1", git = "https://github.com/febo/pinocchio-fork.git", branch = "generic-token2022" }
+pinocchio = { version = "0.11.2", default-features = false }
+pinocchio-token-2022 = "0.4.0"
 
 # TODO: Requires bumping to mollusk beta due to dependency requirements on token-2022-interface v3.1.
 #       It needs solana-instruction v3.4 while mollusk v0.13 requires solana-instruction <3.4.

--- a/mollusk_harness/src/lib.rs
+++ b/mollusk_harness/src/lib.rs
@@ -536,16 +536,56 @@ impl AtaTestHarness {
     pub fn insert_token_account_at_ata_address(&self, owner: Pubkey) -> Pubkey {
         let wallet = self.wallet.as_ref().expect("Wallet must be set");
         let mint = self.mint.expect("Mint must be set");
+
+        self.insert_token_account_at_ata_address_for_token_program(
+            *wallet,
+            mint,
+            owner,
+            self.token_program_id,
+        )
+    }
+
+    /// Insert a token account directly at the canonical ATA address for the
+    /// specified token program.
+    pub fn insert_token_account_at_ata_address_for_token_program(
+        &self,
+        wallet: Pubkey,
+        mint: Pubkey,
+        owner: Pubkey,
+        token_program_id: Pubkey,
+    ) -> Pubkey {
         self.ensure_accounts_with_lamports(&[(owner, 1_000_000)]);
         let ata_address =
-            get_associated_token_address_with_program_id(wallet, &mint, &self.token_program_id);
+            get_associated_token_address_with_program_id(&wallet, &mint, &token_program_id);
         // Create token account with wrong owner at the ATA address
-        let token_account = AccountBuilder::token_account(&mint, &owner, 0, &self.token_program_id);
+        let token_account = AccountBuilder::token_account(&mint, &owner, 0, &token_program_id);
         self.ctx
             .account_store
             .borrow_mut()
             .insert(ata_address, token_account);
         ata_address
+    }
+
+    /// Insert a token account directly at the canonical ATA address for the
+    /// specified token program.
+    pub fn insert_mint_account_for_token_program(
+        &self,
+        mint_authority: Pubkey,
+        decimals: u8,
+        token_program_id: Pubkey,
+    ) -> Pubkey {
+        self.ensure_accounts_with_lamports(&[(mint_authority, 1_000_000)]);
+        let mint_address = Pubkey::new_unique();
+        let mint_account = AccountBuilder::mint_account_with_mint_authority(
+            &mint_authority,
+            decimals,
+            &token_program_id,
+        );
+        self.ctx
+            .account_store
+            .borrow_mut()
+            .insert(mint_address, mint_account);
+        mint_address
     }
 
     /// Execute an instruction with a modified account address (for testing non-ATA addresses)
@@ -789,10 +829,38 @@ impl AccountBuilder {
             close_authority: close_authority.into(),
         };
 
-        if *token_program == spl_token_2022_interface::id() {
+        let mut account = if *token_program == spl_token_2022_interface::id() {
             mollusk_svm_programs_token::token2022::create_account_for_token_account(account_data)
         } else {
             mollusk_svm_programs_token::token::create_account_for_token_account(account_data)
-        }
+        };
+        // Ensure the account is owned by specified token program. This supports testing scenarios
+        // where the account is created with a custom token program.
+        account.owner = *token_program;
+        account
+    }
+
+    pub fn mint_account_with_mint_authority(
+        mint_authority: &Pubkey,
+        decimals: u8,
+        token_program: &Pubkey,
+    ) -> Account {
+        let account_data = Mint {
+            decimals,
+            freeze_authority: COption::None,
+            mint_authority: COption::Some(*mint_authority),
+            is_initialized: true,
+            supply: 0,
+        };
+
+        let mut account = if *token_program == spl_token_2022_interface::id() {
+            mollusk_svm_programs_token::token2022::create_account_for_mint(account_data)
+        } else {
+            mollusk_svm_programs_token::token::create_account_for_mint(account_data)
+        };
+        // Ensure the account is owned by specified token program. This supports testing scenarios
+        // where the account is created with a custom token program.
+        account.owner = *token_program;
+        account
     }
 }

--- a/pinocchio/program/Cargo.toml
+++ b/pinocchio/program/Cargo.toml
@@ -21,7 +21,7 @@ pinocchio = { workspace = true, features = ["cpi"] }
 pinocchio-associated-token-account-interface = { path = "../interface" }
 pinocchio-log = { version = "0.5.1", features = ["macro"] }
 pinocchio-system = "0.6.1"
-pinocchio-token = "0.6.0"
+pinocchio-token = "0.7.0"
 pinocchio-token-2022 = { workspace = true }
 spl-token-2022-interface = "3.1.0"
 

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,3 +1,32 @@
+#### 2026-07-09 02:06:36.402967 UTC
+
+Solana CLI Version: Unknown
+
+| Name | CUs | Delta |
+|------|------|-------|
+| create (spl-token) | 3084 | +1 |
+| create_with_args (spl-token) | 2815 | +3 |
+| create (token-2022) | 5133 | +2 |
+| create_with_args (token-2022) | 5300 | +5 |
+| create_idempotent (new, spl-token) | 4173 | +1 |
+| create_with_args_idempotent (new, spl-token) | 3909 | +3 |
+| create_idempotent (new, token-2022) | 5498 | +2 |
+| create_with_args_idempotent (new, token-2022) | 5670 | +5 |
+| create_idempotent (existing, spl-token) | 529 | +1 |
+| create_with_args_idempotent (existing, spl-token) | 387 | -- |
+| create_idempotent (existing, token-2022) | 1615 | +1 |
+| create_with_args_idempotent (existing, token-2022) | 387 | -- |
+| create (prefunded, spl-token) | 3084 | +1 |
+| create_with_args (prefunded, spl-token) | 2815 | +3 |
+| create (prefunded, token-2022) | 5133 | +2 |
+| create_with_args (prefunded, token-2022) | 5300 | +5 |
+| create (token-2022 known mint) | 6675 | +2 |
+| create_with_args (token-2022 extended mint) | 6116 | +5 |
+| recover_nested (owner=spl-token, nested=spl-token) | 4070 | -1,079 |
+| recover_nested (owner=token-2022, nested=token-2022) | 5517 | -1,496 |
+| recover_nested (owner=spl-token, nested=token-2022) | 8073 | -1,496 |
+| recover_nested (owner=token-2022, nested=spl-token) | 4440 | -1,079 |
+
 #### 2026-06-30 17:04:38.853839 UTC
 
 Solana CLI Version: solana-cli 3.1.8 (src:2717084a; feat:1620780344, client:Agave)

--- a/pinocchio/program/benches/compute_units.md
+++ b/pinocchio/program/benches/compute_units.md
@@ -1,4 +1,4 @@
-#### 2026-07-09 02:06:36.402967 UTC
+#### 2026-08-05 23:59:47.670023 UTC
 
 Solana CLI Version: Unknown
 
@@ -22,10 +22,10 @@ Solana CLI Version: Unknown
 | create_with_args (prefunded, token-2022) | 5300 | +5 |
 | create (token-2022 known mint) | 6675 | +2 |
 | create_with_args (token-2022 extended mint) | 6116 | +5 |
-| recover_nested (owner=spl-token, nested=spl-token) | 4070 | -1,079 |
-| recover_nested (owner=token-2022, nested=token-2022) | 5517 | -1,496 |
-| recover_nested (owner=spl-token, nested=token-2022) | 8073 | -1,496 |
-| recover_nested (owner=token-2022, nested=spl-token) | 4440 | -1,079 |
+| recover_nested (owner=spl-token, nested=spl-token) | 4086 | -1,063 |
+| recover_nested (owner=token-2022, nested=token-2022) | 5536 | -1,477 |
+| recover_nested (owner=spl-token, nested=token-2022) | 8092 | -1,477 |
+| recover_nested (owner=token-2022, nested=spl-token) | 4456 | -1,063 |
 
 #### 2026-06-30 17:04:38.853839 UTC
 

--- a/pinocchio/program/src/batch.rs
+++ b/pinocchio/program/src/batch.rs
@@ -53,6 +53,7 @@ pub(crate) fn batch_init_and_lock_owner(
 }
 
 // This cannot be inlined because it makes the call site stack frame too large.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn batch_transfer_and_close(
     token_program: &Address,
     nested_ata: &AccountView,

--- a/pinocchio/program/src/batch.rs
+++ b/pinocchio/program/src/batch.rs
@@ -1,35 +1,16 @@
 use {
-    core::{mem::MaybeUninit, slice::from_raw_parts},
+    core::mem::MaybeUninit,
     pinocchio::{
         AccountView, Address, ProgramResult,
-        cpi::{CpiAccount, invoke_unchecked},
-        instruction::{InstructionAccount, InstructionView},
+        cpi::{CpiAccount, Signer},
+        instruction::InstructionAccount,
     },
-    pinocchio_token::instructions::{
-        Batch, InitializeAccount, InitializeAccount3, InitializeImmutableOwner, IntoBatch,
+    pinocchio_token_2022::instructions::{
+        Batch, CloseAccount, InitializeAccount, InitializeAccount3, InitializeImmutableOwner,
+        IntoBatch, TransferChecked,
     },
 };
 
-struct BatchLens {
-    data: usize,
-    accounts: usize,
-}
-
-const INIT_WITH_ACCOUNT: BatchLens = BatchLens {
-    data: Batch::header_data_len(2)
-        + InitializeImmutableOwner::DATA_LEN
-        + InitializeAccount::DATA_LEN,
-    accounts: InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount::ACCOUNTS_LEN,
-};
-const INIT_WITH_ACCOUNT3: BatchLens = BatchLens {
-    data: Batch::header_data_len(2)
-        + InitializeImmutableOwner::DATA_LEN
-        + InitializeAccount3::DATA_LEN,
-    accounts: InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount3::ACCOUNTS_LEN,
-};
-// TODO: `pinocchio-token` v0.6 provides a Batch builder but its `invoke()` method hardcodes
-//       SPL Token's program ID. `pinocchio-token-2022` does not yet offer its own batch builder.
-//       Once it does, this can be replaced.
 #[inline(always)]
 pub(crate) fn batch_init_and_lock_owner(
     token_program: &Address,
@@ -38,40 +19,78 @@ pub(crate) fn batch_init_and_lock_owner(
     owner: &AccountView,
     rent_sysvar: Option<&AccountView>,
 ) -> ProgramResult {
-    // `InitializeAccount3` has the larger data payload, `InitializeAccount` has
-    // the larger account list because it includes the rent sysvar.
-    let mut data = [const { MaybeUninit::<u8>::uninit() }; INIT_WITH_ACCOUNT3.data];
+    /// `InitializeAccount` requires more accounts than `InitializeAccount3`,
+    /// so the maximum is based on the former.
+    const MAX_ACCOUNTS_LEN: usize =
+        InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount::ACCOUNTS_LEN;
+
+    /// `InitializeAccount3` requires more instruction data than `InitializeAccount`,
+    /// so the maximum is based on the former.
+    const MAX_DATA_LEN: usize = Batch::header_data_len(2)
+        + InitializeImmutableOwner::DATA_LEN
+        + InitializeAccount3::DATA_LEN;
+
+    let mut data = [const { MaybeUninit::<u8>::uninit() }; MAX_DATA_LEN];
     let mut instruction_accounts =
-        [const { MaybeUninit::<InstructionAccount>::uninit() }; INIT_WITH_ACCOUNT.accounts];
-    let mut cpi_accounts =
-        [const { MaybeUninit::<CpiAccount>::uninit() }; INIT_WITH_ACCOUNT.accounts];
+        [const { MaybeUninit::<InstructionAccount>::uninit() }; MAX_ACCOUNTS_LEN];
+    let mut cpi_accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; MAX_ACCOUNTS_LEN];
 
     // Serialize both sub-instructions into the buffers
     let mut batch = Batch::new(&mut data, &mut instruction_accounts, &mut cpi_accounts)?;
+
     InitializeImmutableOwner::new(account).into_batch(&mut batch)?;
-    let lens = match rent_sysvar {
+
+    match rent_sysvar {
         Some(rent_sysvar) => {
             InitializeAccount::new(account, mint, owner, rent_sysvar).into_batch(&mut batch)?;
-            INIT_WITH_ACCOUNT
         }
         None => {
             InitializeAccount3::new(account, mint, owner.address()).into_batch(&mut batch)?;
-            INIT_WITH_ACCOUNT3
         }
     };
 
-    // Mirrors `Batch::invoke_signed()` but with a supplied program id:
-    // https://github.com/anza-xyz/pinocchio/blob/pinocchio-token%40v0.6.0/programs/token/src/instructions/batch.rs#L92-L105
-    unsafe {
-        invoke_unchecked(
-            &InstructionView {
-                program_id: token_program,
-                accounts: from_raw_parts(instruction_accounts.as_ptr() as _, lens.accounts),
-                data: from_raw_parts(data.as_ptr() as _, lens.data),
-            },
-            from_raw_parts(cpi_accounts.as_ptr().cast(), lens.accounts),
-        );
-    }
+    batch.invoke_with_unverified_program(token_program)
+}
 
-    Ok(())
+// This cannot be inlined because it makes the call site stack frame too large.
+pub(crate) fn batch_transfer_and_close(
+    token_program: &Address,
+    nested_ata: &AccountView,
+    nested_token_mint: &AccountView,
+    destination_ata: &AccountView,
+    owner_ata: &AccountView,
+    wallet: &AccountView,
+    amount: u64,
+    decimals: u8,
+    signer: &[Signer],
+) -> ProgramResult {
+    const MAX_ACCOUNTS_LEN: usize =
+        TransferChecked::MAX_ACCOUNTS_LEN + CloseAccount::MAX_ACCOUNTS_LEN;
+
+    const DATA_LEN: usize =
+        Batch::header_data_len(2) + TransferChecked::DATA_LEN + CloseAccount::DATA_LEN;
+
+    let mut data = [const { MaybeUninit::<u8>::uninit() }; DATA_LEN];
+    let mut instruction_accounts =
+        [const { MaybeUninit::<InstructionAccount>::uninit() }; MAX_ACCOUNTS_LEN];
+    let mut cpi_accounts = [const { MaybeUninit::<CpiAccount>::uninit() }; MAX_ACCOUNTS_LEN];
+
+    // Serialize both sub-instructions into the buffers
+    let mut batch = Batch::new(&mut data, &mut instruction_accounts, &mut cpi_accounts)?;
+
+    // Move all tokens from the nested ATA to the wallet's correct ATA
+    TransferChecked::new(
+        nested_ata,
+        nested_token_mint,
+        destination_ata,
+        owner_ata,
+        amount,
+        decimals,
+    )
+    .into_batch(&mut batch)?;
+
+    // Close the now-empty nested ATA and return its rent lamports to the wallet
+    CloseAccount::new(nested_ata, wallet, owner_ata).into_batch(&mut batch)?;
+
+    batch.invoke_signed_with_unverified_program(signer, token_program)
 }

--- a/pinocchio/program/src/batch.rs
+++ b/pinocchio/program/src/batch.rs
@@ -5,7 +5,7 @@ use {
         cpi::{CpiAccount, Signer},
         instruction::InstructionAccount,
     },
-    pinocchio_token_2022::instructions::{
+    pinocchio_token::instructions::{
         Batch, CloseAccount, InitializeAccount, InitializeAccount3, InitializeImmutableOwner,
         IntoBatch, TransferChecked,
     },
@@ -19,13 +19,14 @@ pub(crate) fn batch_init_and_lock_owner(
     owner: &AccountView,
     rent_sysvar: Option<&AccountView>,
 ) -> ProgramResult {
-    /// `InitializeAccount` requires more accounts than `InitializeAccount3`,
-    /// so the maximum is based on the former.
+    // `InitializeAccount` requires more accounts than `InitializeAccount3`,
+    // so the maximum is based on the former.
     const MAX_ACCOUNTS_LEN: usize =
         InitializeImmutableOwner::ACCOUNTS_LEN + InitializeAccount::ACCOUNTS_LEN;
 
-    /// `InitializeAccount3` requires more instruction data than `InitializeAccount`,
-    /// so the maximum is based on the former.
+    // `InitializeAccount3` requires more instruction data than `InitializeAccount`,
+    // so the maximum is based on the former and we have 2 inner instructions in
+    // the header.
     const MAX_DATA_LEN: usize = Batch::header_data_len(2)
         + InitializeImmutableOwner::DATA_LEN
         + InitializeAccount3::DATA_LEN;
@@ -68,6 +69,7 @@ pub(crate) fn batch_transfer_and_close(
     const MAX_ACCOUNTS_LEN: usize =
         TransferChecked::MAX_ACCOUNTS_LEN + CloseAccount::MAX_ACCOUNTS_LEN;
 
+    // We have 2 inner instructions in the header.
     const DATA_LEN: usize =
         Batch::header_data_len(2) + TransferChecked::DATA_LEN + CloseAccount::DATA_LEN;
 

--- a/pinocchio/program/src/batch.rs
+++ b/pinocchio/program/src/batch.rs
@@ -11,6 +11,7 @@ use {
     },
 };
 
+// Note: The `token_program` address is not verified by this function.
 #[inline(always)]
 pub(crate) fn batch_init_and_lock_owner(
     token_program: &Address,
@@ -50,6 +51,8 @@ pub(crate) fn batch_init_and_lock_owner(
         }
     };
 
+    // The `token_program` address is verified by the caller. It is only used by
+    // `CreateAssociatedTokenAccount` processor.
     batch.invoke_with_unverified_program(token_program)
 }
 
@@ -95,5 +98,5 @@ pub(crate) fn batch_transfer_and_close(
     // Close the now-empty nested ATA and return its rent lamports to the wallet
     CloseAccount::new(nested_ata, wallet, owner_ata).into_batch(&mut batch)?;
 
-    batch.invoke_signed_with_unverified_program(signer, token_program)
+    batch.invoke_signed_with_program(signer, token_program)
 }

--- a/pinocchio/program/src/recover.rs
+++ b/pinocchio/program/src/recover.rs
@@ -1,15 +1,18 @@
 use {
-    crate::error::{
-        destination_associated_address_mismatch, missing_required_signature,
-        nested_associated_address_mismatch, nested_ata_illegal_owner, nested_ata_invalid_owner,
-        nested_mint_illegal_owner, not_enough_account_keys, not_enough_multisig_signers,
-        owner_associated_address_mismatch, owner_ata_illegal_owner, owner_ata_invalid_owner,
-        owner_mint_illegal_owner, uninitialized_account, wallet_missing_required_signature,
+    crate::{
+        batch::batch_transfer_and_close,
+        error::{
+            destination_associated_address_mismatch, missing_required_signature,
+            nested_associated_address_mismatch, nested_ata_illegal_owner, nested_ata_invalid_owner,
+            nested_mint_illegal_owner, not_enough_account_keys, not_enough_multisig_signers,
+            owner_associated_address_mismatch, owner_ata_illegal_owner, owner_ata_invalid_owner,
+            owner_mint_illegal_owner, uninitialized_account, wallet_missing_required_signature,
+        },
     },
     pinocchio::{AccountView, Address, ProgramResult, cpi::Signer, instruction::seeds},
     pinocchio_associated_token_account_interface::pda::AssociatedTokenPda,
     pinocchio_token_2022::{
-        instructions::{CloseAccount, MAX_MULTISIG_SIGNERS, TransferChecked},
+        instructions::MAX_MULTISIG_SIGNERS,
         state::{Account, Mint, Multisig, StateWithExtensions},
     },
 };
@@ -161,26 +164,17 @@ pub(crate) fn process_recover_nested(
         bump_ref
     );
 
-    // Move all tokens from the nested ATA to the wallet's correct ATA
-    TransferChecked {
-        from: nested_ata,
-        mint: nested_token_mint,
-        to: destination_ata,
-        authority: owner_ata,
+    batch_transfer_and_close(
+        nested_token_program.address(),
+        nested_ata,
+        nested_token_mint,
+        destination_ata,
+        owner_ata,
+        wallet,
         amount,
         decimals,
-        token_program: nested_token_program.address(),
-    }
-    .invoke_signed(&[Signer::from(&seeds)])?;
-
-    // Close the now-empty nested ATA and return its rent lamports to the wallet
-    CloseAccount {
-        account: nested_ata,
-        destination: wallet,
-        authority: owner_ata,
-        token_program: nested_token_program.address(),
-    }
-    .invoke_signed(&[Signer::from(&seeds)])
+        &[Signer::from(&seeds)],
+    )
 }
 
 #[cold]

--- a/pinocchio/program/src/size.rs
+++ b/pinocchio/program/src/size.rs
@@ -57,12 +57,8 @@ fn get_account_data_size_cpi(
 ) -> Result<u64, ProgramError> {
     let token_program_address = token_program.address();
 
-    GetAccountDataSize {
-        mint,
-        extensions: &[ExtensionType::ImmutableOwner],
-        token_program: token_program_address,
-    }
-    .invoke()?;
+    GetAccountDataSize::new(mint, &[ExtensionType::ImmutableOwner])
+        .invoke_with_program(token_program_address)?;
 
     get_return_data()
         .ok_or_else(no_account_size_return_data)

--- a/pinocchio/program/tests/recover_nested.rs
+++ b/pinocchio/program/tests/recover_nested.rs
@@ -20,6 +20,7 @@ const TEST_MINT_AMOUNT: u64 = 100;
 struct RecoverNestedSetup {
     harness: AtaTestHarness,
     wallet: Address,
+    owner_ata: Address,
     owner_mint: Address,
     nested_mint: Address,
     nested_ata: Address,
@@ -86,6 +87,7 @@ fn recover_nested_setup_for_wallet(
     RecoverNestedSetup {
         harness,
         wallet,
+        owner_ata,
         owner_mint,
         nested_mint,
         nested_ata,
@@ -613,4 +615,52 @@ fn success_extra_signer_accounts_ignored() {
         .is_signer = false;
 
     assert_recover_nested_success(setup, recover_instruction);
+}
+
+#[test]
+fn fail_unsupported_token_program() {
+    let setup = recover_nested_setup(spl_token_interface::id(), spl_token_interface::id());
+
+    let unsupported_token_program_id = Address::new_unique();
+
+    // `nested_mint` is created for the unsupported token program.
+    let nested_mint = setup.harness.insert_mint_account_for_token_program(
+        setup.wallet,
+        9,
+        unsupported_token_program_id,
+    );
+
+    // `destination_ata` is created for the unsupported token program.
+    setup
+        .harness
+        .insert_token_account_at_ata_address_for_token_program(
+            setup.wallet,
+            nested_mint,
+            setup.wallet,
+            unsupported_token_program_id,
+        );
+
+    // `nested_ata` is created for the unsupported token program.
+    setup
+        .harness
+        .insert_token_account_at_ata_address_for_token_program(
+            setup.owner_ata,
+            nested_mint,
+            setup.owner_ata,
+            unsupported_token_program_id,
+        );
+
+    let recover_instruction = build_recover_nested_instruction(
+        &setup.wallet,
+        &setup.owner_mint,
+        &nested_mint,
+        &spl_token_interface::id(),
+        &unsupported_token_program_id,
+        &[],
+    );
+
+    setup.harness.ctx.process_and_validate_instruction(
+        &recover_instruction,
+        &[Check::err(ProgramError::IncorrectProgramId)],
+    );
 }


### PR DESCRIPTION
### Problem

With PR https://github.com/anza-xyz/pinocchio/pull/428, pinocchio-token helpers are generic so `Batch` is now available for Token-2022.

### Solution

Update pinocchio token crate versions and use the generic helpers. Since batch is available, it can be used in recover nested processor.

| Name | CUs | Delta |
|------|------|-------|
| create (spl-token) | 3084 | +1 |
| create_with_args (spl-token) | 2815 | +3 |
| create (token-2022) | 5133 | +2 |
| create_with_args (token-2022) | 5300 | +5 |
| create_idempotent (new, spl-token) | 4173 | +1 |
| create_with_args_idempotent (new, spl-token) | 3909 | +3 |
| create_idempotent (new, token-2022) | 5498 | +2 |
| create_with_args_idempotent (new, token-2022) | 5670 | +5 |
| create_idempotent (existing, spl-token) | 529 | +1 |
| create_with_args_idempotent (existing, spl-token) | 387 | -- |
| create_idempotent (existing, token-2022) | 1615 | +1 |
| create_with_args_idempotent (existing, token-2022) | 387 | -- |
| create (prefunded, spl-token) | 3084 | +1 |
| create_with_args (prefunded, spl-token) | 2815 | +3 |
| create (prefunded, token-2022) | 5133 | +2 |
| create_with_args (prefunded, token-2022) | 5300 | +5 |
| create (token-2022 known mint) | 6675 | +2 |
| create_with_args (token-2022 extended mint) | 6116 | +5 |
| recover_nested (owner=spl-token, nested=spl-token) | 4070 | -1,063 |
| recover_nested (owner=token-2022, nested=token-2022) | 5517 | -1,477 |
| recover_nested (owner=spl-token, nested=token-2022) | 8073 | -1,477 |
| recover_nested (owner=token-2022, nested=spl-token) | 4440 | -1,063 |