### PR TITLE
ci: bind package-path workflow input before shell use

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -55,10 +55,12 @@ jobs:
       - name: Compute variables
         id: compute
         shell: bash
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
         run: |
           echo "RUST_TOOLCHAIN_NIGHTLY=$(make rust-toolchain-nightly)" >> "$GITHUB_OUTPUT"
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
-          TARGET=$(echo ${{ inputs.package-path }} | sed 's#/#-#')
+          TARGET=$(echo "$PACKAGE_PATH" | sed 's#/#-#')
           echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
   main:


### PR DESCRIPTION
## Summary
Binds `inputs.package-path` into step `env:` before shell use in `.github/workflows/publish-rust.yml`, so workflow inputs are not interpolated directly into bash.

## Context
GitHub Actions expands `${{ inputs.* }}` before the shell runs. Binding through `env:` keeps the value out of the script text.

## Test plan
- [ ] Confirm `publish-rust` workflow YAML still validates
- [ ] Dry-run / next publish path still computes `TARGET` from `package-path`

Made with [Cursor](https://cursor.com)