### PR TITLE
Add clear-signing display directives to the interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "codama"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5279023f0b151f721bd9f91750738b8d8349c5b32bd1f121cd9c354aaeb1f7"
+checksum = "6d3f54c527ab6dad39190e0ed5be39d964c81c842eb08971c26de8214c18dc9a"
 dependencies = [
  "codama-errors",
  "codama-korok-visitors",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "codama-attributes"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319da8de964230be2786ae5ddc96144e7ef634e3d270fd8d8e8a4c3f3b03cc75"
+checksum = "4fbc65cfb6876d02c21eb6fbbb188708351574e44f5848a1b682f4e9f6826a37"
 dependencies = [
  "codama-errors",
  "codama-nodes",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "codama-errors"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1469342ef520f878f9dffa2b92339bb738024d18f67c695710b706ddbb7f65a5"
+checksum = "9c4e65ee3ef3464d660567139bc313368c3d13c1f4a84f455f4b20ba90ba0320"
 dependencies = [
  "cargo_toml",
  "proc-macro2",
@@ -636,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "codama-korok-visitors"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ddead510becae7f9ccd5a508e21daea4732c16ffd55644262305e2e3dad27e"
+checksum = "2dabf0f200df043e7deed645fad5f60befaebc0991aa170cbdceb295d8da91d4"
 dependencies = [
  "cargo_toml",
  "codama-attributes",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "codama-koroks"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a5a9cf35ff01d3c64835f0b8661e6eab552aaffc5acbd22fe81b99b4412631"
+checksum = "7aaf54ba9b675911ef6baff152df96d55e2228cbe5e103fd0c76d823932d7ae9"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "codama-macros"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f106658328f05ed9018110788a8251f048b3fa56487fbafe005a38cfb34046e"
+checksum = "a7eb88686d13afa2983ad1ab294bc1ee226ddcd63ef290b6d44bb78e42c87a6f"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87b3d1b268882b1f1f2a43b536ba4bdaf422488e62f7f67731822aa5681ca5b"
+checksum = "4c233b476fe665182fde18ca7afc43b5385622367ac6d98661c0c6748f93a9b0"
 dependencies = [
  "codama-errors",
  "codama-nodes-derive",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "codama-nodes-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d290c129a35225acf486daaf66d4c3896aee44086cbdb07f0e4f20d67365f"
+checksum = "86315bc36007da03157be9657e24f3235e5cf53b384f15a4b03c484a2b087487"
 dependencies = [
  "codama-errors",
  "codama-syn-helpers",
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "codama-plugin-core"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346167044ea2fae899ef57b800b4b5b53390d091046d8fc4b76e5bce6d7ae7c6"
+checksum = "9c481fd44427b6088c2903cb93ad1322f9fd83e6ab08c5b7fbb9b8c59c7f4e24"
 dependencies = [
  "codama-attributes",
  "codama-errors",
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "codama-stores"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2b32f6053220c34877fa0267c006b8419fce78ee0cf286e04df7095f93133"
+checksum = "55cd34fddc3f7ec44f62d5a75fcde422f7bdfa7662a1432ea38957482ec52750"
 dependencies = [
  "cargo_toml",
  "codama-errors",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "codama-syn-helpers"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef1c5c5ca7519e115a6d2ed240dbc4cbe16c05f241f3aaf5f1fb623b8d3b17e"
+checksum = "0c32b8d72d636d82ffe8cb2e614fbc5c84d897b5969eb27dfac226d944efe361"
 dependencies = [
  "codama-errors",
  "derive_more",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ generate-clients:
 	@echo "No JavaScript clients to generate"
 
 generate-idl-%:
-	@cargo install --locked --version =0.9.1 codama-cli
+	@cargo install --locked --version =0.11.0 codama-cli
 	codama-rs generate-idl $(call make-path,$*) -o $(call make-path,$*)/idl.json --pretty $(ARGS)
 
 audit:

--- a/pinocchio/interface/Cargo.toml
+++ b/pinocchio/interface/Cargo.toml
@@ -14,8 +14,8 @@ crate-type = ["rlib"]
 codama = ["dep:codama", "dep:codama-macros"]
 
 [dependencies]
-codama = { version = "0.10.0", optional = true }
-codama-macros = { version = "0.10.0", optional = true }
+codama = { version = "0.11.0", optional = true }
+codama-macros = { version = "0.11.0", optional = true }
 pinocchio = { workspace = true }
 solana-address = { version = "2.6.1", features = ["curve25519", "decode"] }
 solana-nullable = { version = "1.1.1", features = ["wincode"] }

--- a/pinocchio/interface/idl.json
+++ b/pinocchio/interface/idl.json
@@ -1,13 +1,12 @@
 {
   "kind": "rootNode",
   "standard": "codama",
-  "version": "1.0.0",
+  "version": "1.8.0",
   "program": {
     "kind": "programNode",
     "name": "pinocchioAssociatedTokenAccountInterface",
     "publicKey": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
     "version": "0.1.0",
-    "accounts": [],
     "instructions": [
       {
         "kind": "instructionNode",
@@ -29,7 +28,11 @@
             "isSigner": false,
             "docs": [
               "Associated token account address to be created"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -60,6 +63,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -85,6 +92,10 @@
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 0
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -94,7 +105,12 @@
             "name": "discriminator",
             "offset": 0
           }
-        ]
+        ],
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Create associated token account",
+          "interpolatedIntent": "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -116,7 +132,11 @@
             "isSigner": false,
             "docs": [
               "Associated token account address to be created"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -147,6 +167,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -172,6 +196,10 @@
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 1
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -181,7 +209,12 @@
             "name": "discriminator",
             "offset": 0
           }
-        ]
+        ],
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Create associated token account",
+          "interpolatedIntent": "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -195,7 +228,11 @@
             "isSigner": false,
             "docs": [
               "Nested associated token account, must be owned by `owner_associated_token_account`"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Nested Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -213,7 +250,11 @@
             "isSigner": false,
             "docs": [
               "Wallet's associated token account"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Destination Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -222,7 +263,11 @@
             "isSigner": false,
             "docs": [
               "Owner associated token account address, must be owned by `wallet`"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Owner Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -275,6 +320,10 @@
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 2
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -284,7 +333,12 @@
             "name": "discriminator",
             "offset": 0
           }
-        ]
+        ],
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Recover nested token account",
+          "interpolatedIntent": "Recover nested token account ${accounts.nestedAssociatedTokenAccount} to ${accounts.destinationAssociatedTokenAccount}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -307,7 +361,11 @@
             "isSigner": false,
             "docs": [
               "Associated token account address to be created"
-            ]
+            ],
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "Token Account"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -338,6 +396,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "11111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -361,6 +423,10 @@
             "defaultValue": {
               "kind": "publicKeyValueNode",
               "publicKey": "SysvarRent111111111111111111111111111111111"
+            },
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -377,6 +443,10 @@
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 3
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -394,6 +464,10 @@
               "kind": "numberTypeNode",
               "format": "u8",
               "endian": "le"
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -403,6 +477,10 @@
               "kind": "numberTypeNode",
               "format": "u32",
               "endian": "le"
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -412,7 +490,12 @@
             "name": "discriminator",
             "offset": 0
           }
-        ]
+        ],
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Create associated token account",
+          "interpolatedIntent": "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        }
       }
     ],
     "definedTypes": [
@@ -470,7 +553,6 @@
         ]
       }
     ],
-    "events": [],
     "errors": [
       {
         "kind": "errorNode",
@@ -479,6 +561,5 @@
         "message": "Associated token account owner does not match address derivation"
       }
     ]
-  },
-  "additionalPrograms": []
+  }
 }

--- a/pinocchio/interface/src/instruction.rs
+++ b/pinocchio/interface/src/instruction.rs
@@ -26,6 +26,10 @@ pub enum AssociatedTokenAccountInstruction {
     ///   5. `[]` SPL Token program
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Create associated token account",
+            interpolated_intent = "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        )),
         codama(account(
             name = "funder",
             signer,
@@ -35,14 +39,16 @@ pub enum AssociatedTokenAccountInstruction {
         codama(account(
             name = "associated_token_account",
             writable,
-            docs = "Associated token account address to be created"
+            docs = "Associated token account address to be created",
+            display(label = "Token Account")
         )),
         codama(account(name = "wallet", docs = "Wallet address for the new associated token account")),
         codama(account(name = "mint", docs = "The token mint for the new associated token account")),
         codama(account(
             name = "system_program",
             docs = "System program",
-            default_value = program("system")
+            default_value = program("system"),
+            display(skip = always)
         )),
         codama(account(name = "token_program", docs = "SPL Token program"))
     )]
@@ -59,6 +65,10 @@ pub enum AssociatedTokenAccountInstruction {
     ///   5. `[]` SPL Token program
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Create associated token account",
+            interpolated_intent = "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        )),
         codama(account(
             name = "funder",
             signer,
@@ -68,14 +78,16 @@ pub enum AssociatedTokenAccountInstruction {
         codama(account(
             name = "associated_token_account",
             writable,
-            docs = "Associated token account address to be created"
+            docs = "Associated token account address to be created",
+            display(label = "Token Account")
         )),
         codama(account(name = "wallet", docs = "Wallet address for the new associated token account")),
         codama(account(name = "mint", docs = "The token mint for the new associated token account")),
         codama(account(
             name = "system_program",
             docs = "System program",
-            default_value = program("system")
+            default_value = program("system"),
+            display(skip = always)
         )),
         codama(account(name = "token_program", docs = "SPL Token program"))
     )]
@@ -119,12 +131,17 @@ pub enum AssociatedTokenAccountInstruction {
     ///      wallet
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Recover nested token account",
+            interpolated_intent = "Recover nested token account ${accounts.nestedAssociatedTokenAccount} to ${accounts.destinationAssociatedTokenAccount}"
+        )),
         codama(optional_account_strategy = omitted),
         codama(account(
             name = "nested_associated_token_account",
             writable,
             docs = "Nested associated token account, must be owned by \
-                    `owner_associated_token_account`"
+                    `owner_associated_token_account`",
+            display(label = "Nested Token Account")
         )),
         codama(account(
             name = "nested_mint",
@@ -133,11 +150,13 @@ pub enum AssociatedTokenAccountInstruction {
         codama(account(
             name = "destination_associated_token_account",
             writable,
-            docs = "Wallet's associated token account"
+            docs = "Wallet's associated token account",
+            display(label = "Destination Token Account")
         )),
         codama(account(
             name = "owner_associated_token_account",
-            docs = "Owner associated token account address, must be owned by `wallet`"
+            docs = "Owner associated token account address, must be owned by `wallet`",
+            display(label = "Owner Token Account")
         )),
         codama(account(
             name = "owner_mint",
@@ -173,6 +192,10 @@ pub enum AssociatedTokenAccountInstruction {
     ///   6. `[]` Optional rent sysvar
     #[cfg_attr(
         feature = "codama",
+        codama(display(
+            intent = "Create associated token account",
+            interpolated_intent = "Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}"
+        )),
         codama(optional_account_strategy = omitted),
         codama(account(
             name = "funder",
@@ -183,31 +206,42 @@ pub enum AssociatedTokenAccountInstruction {
         codama(account(
             name = "associated_token_account",
             writable,
-            docs = "Associated token account address to be created"
+            docs = "Associated token account address to be created",
+            display(label = "Token Account")
         )),
         codama(account(name = "wallet", docs = "Wallet address for the new associated token account")),
         codama(account(name = "mint", docs = "The token mint for the new associated token account")),
         codama(account(
             name = "system_program",
             docs = "System program",
-            default_value = program("system")
+            default_value = program("system"),
+            display(skip = always)
         )),
         codama(account(name = "token_program", docs = "SPL Token program")),
         codama(account(
             name = "rent_sysvar",
             optional,
             default_value = sysvar("rent"),
-            docs = "Optional rent sysvar"
+            docs = "Optional rent sysvar",
+            display(skip = always)
         ))
     )]
     CreateWithArgs {
         /// Selects whether behaves like `Create` or `CreateIdempotent`.
         mode: CreateMode,
         /// The ATA PDA bump seed.
-        #[cfg_attr(feature = "codama", codama(type = number(u8)))]
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = number(u8)),
+            codama(display(skip = always))
+        )]
         bump: MaybeNull<BumpSeedHint>,
         /// The account data length for the new ATA.
-        #[cfg_attr(feature = "codama", codama(type = number(u32)))]
+        #[cfg_attr(
+            feature = "codama",
+            codama(type = number(u32)),
+            codama(display(skip = always))
+        )]
         account_len: MaybeNull<AccountLenHint>,
     },
 }


### PR DESCRIPTION
This PR annotates the four Associated Token Account instructions with clear-signing display metadata, using the display directives introduced in codama 0.11.0, and regenerates the IDL.

- `create` / `createIdempotent` / `createWithArgs` share the intent `Create associated token account` and the sentence `Create the associated token account of ${accounts.wallet} for mint ${accounts.mint}`, matching the copy already applied to the token and token-2022 IDLs.
- `recoverNested` renders `Recover nested token account ${accounts.nestedAssociatedTokenAccount} to ${accounts.destinationAssociatedTokenAccount}`, with the same account labels as the token-program variant of this instruction.
- Structural members are hidden from the fallback list: `systemProgram`, `rentSysvar`, and the `bump`/`accountLen` PDA/allocation hints (`skip: always`). `tokenProgram` stays visible. Discriminators are skipped automatically by codama 0.11.0.
- Bumps `codama`/`codama-macros` from 0.10.0 to 0.11.0 and the `codama-cli` pin from 0.9.1 to 0.11.0.

Verified with `cargo check --features codama`, clippy, fmt, the wire-format tests, and by rendering every instruction of the regenerated IDL through `@codama/dynamic-instructions` 0.4.0.
